### PR TITLE
Moved from Byte to Boolean in Garbled Circuits

### DIFF
--- a/src/java/edu/biu/SCProtocols/YaoProtocol/src/PartyTwo.java
+++ b/src/java/edu/biu/SCProtocols/YaoProtocol/src/PartyTwo.java
@@ -134,7 +134,7 @@ public class PartyTwo {
 		if (!(msg instanceof HashMap<?, ?>)){
 			throw new CheatAttemptException("the received message should be an instance of HashMap<Integer, Byte>");
 		}
-		HashMap<Integer, Byte> translationTable = (HashMap<Integer, Byte>) msg;
+		HashMap<Integer, Boolean> translationTable = (HashMap<Integer, Boolean>) msg;
 			
 		//Set garbled tables and translation table to the circuit.
 		circuit.setGarbledTables(garbledTables);

--- a/src/java/edu/biu/scapi/circuits/circuit/Gate.java
+++ b/src/java/edu/biu/scapi/circuits/circuit/Gate.java
@@ -167,7 +167,7 @@ public class Gate {
 	private int calculateIndexOfTruthTable(Map<Integer, Wire> computedWires) {
   
 		/*
-		 * Since a truth table’s order is the order of binary counting, the index of a desired row can be calculated as follows: 
+		 * Since a truth tableï¿½s order is the order of binary counting, the index of a desired row can be calculated as follows: 
 		 * For a truth table with L inputs whose input columns are labeled aL...ai...a2,a1, 
 		 * the output index for a given input set is given by: summation from 0 to L : ai *2^i. 
 		 * This is calculated below:
@@ -175,7 +175,8 @@ public class Gate {
 		int truthTableIndex = 0;
 		int numberOfInputs = inputWireIndices.length;
 		for (int i = numberOfInputs - 1, j = 0; j < numberOfInputs; i--, j++) {
-			truthTableIndex += computedWires.get(inputWireIndices[i]).getValue() * Math.pow(2, j);
+			final boolean wireValue = computedWires.get(inputWireIndices[i]).getValue();
+			truthTableIndex += ((wireValue == true) ? 1 : 0) * Math.pow(2, j);
 		}
 		return truthTableIndex;
 	}

--- a/src/java/edu/biu/scapi/circuits/circuit/Wire.java
+++ b/src/java/edu/biu/scapi/circuits/circuit/Wire.java
@@ -36,7 +36,7 @@ public class Wire {
 	/**
 	 * The value that this wire carries. It can be set to either 0 or 1
   	 */
-	private byte value;
+	private boolean value;
 
 	/**
 	 * Creates a {@code Wire} and sets it to the specified value.
@@ -48,7 +48,7 @@ public class Wire {
 		if (value < 0 || value > 1) {
 			  throw new IllegalArgumentException("Wire value can only be 0 or 1");
 		} else {
-			this.value = value;
+			this.value = value==1 ? true : false;
 		}
 	}
 
@@ -60,7 +60,7 @@ public class Wire {
 	 * 
 	 * @return the value (0 or 1) that this {@code Wire} is set to.
 	 */
-	public byte getValue() {
+	public boolean getValue() {
 		return value;
 	}
 }

--- a/src/java/edu/biu/scapi/circuits/circuit/Wire.java
+++ b/src/java/edu/biu/scapi/circuits/circuit/Wire.java
@@ -52,6 +52,10 @@ public class Wire {
 		}
 	}
 
+	public Wire(boolean value) {
+		this(value ? (byte) 1 : (byte) 0);
+	}
+
 	/**
 	 * 
 	 * @return the value (0 or 1) that this {@code Wire} is set to.

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/CircuitCreationValues.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/CircuitCreationValues.java
@@ -41,7 +41,7 @@ import javax.crypto.SecretKey;
 public class CircuitCreationValues {
 	private Map<Integer, SecretKey[]> allInputWireValues;
 	private Map<Integer, SecretKey[]> allOutputWireValues;
-	private HashMap<Integer, Byte> translationTable;
+	private HashMap<Integer, Boolean> translationTable;
 	
 	/**
 	 * Sets the given arguments.
@@ -50,7 +50,7 @@ public class CircuitCreationValues {
 	 * @param translationTable Signal bits of all output wires.
 	 */
 	public CircuitCreationValues(Map<Integer, SecretKey[]> allInputWireValues, Map<Integer, SecretKey[]> allOutputWireValues, 
-			HashMap<Integer, Byte> translationTable) {
+			HashMap<Integer, Boolean> translationTable) {
 		this.allInputWireValues = allInputWireValues;
 		this.allOutputWireValues = allOutputWireValues;
 		this.translationTable = translationTable;
@@ -64,7 +64,7 @@ public class CircuitCreationValues {
 		return allOutputWireValues;
 	}
 
-	public HashMap<Integer, Byte> getTranslationTable() {
+	public HashMap<Integer, Boolean> getTranslationTable() {
 		return translationTable;
 	}
 }

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/FreeXORGarbledBooleanCircuitUtil.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/FreeXORGarbledBooleanCircuitUtil.java
@@ -133,7 +133,7 @@ class FreeXORGarbledBooleanCircuitUtil implements CircuitTypeUtil {
 		Map<Integer, SecretKey[]> allWireValues = new HashMap<Integer, SecretKey[]>();
 		Map<Integer, SecretKey[]> allInputWireValues = null;
 		Map<Integer, SecretKey[]> allOutputWireValues = null;
-		HashMap<Integer, Byte> translationTable = new HashMap<Integer, Byte>();
+		HashMap<Integer, Boolean> translationTable = new HashMap<>();
 		Gate[] ungarbledGates = ungarbledCircuit.getGates();
 		byte[] globalKeyOffset = null;
 		
@@ -172,7 +172,7 @@ class FreeXORGarbledBooleanCircuitUtil implements CircuitTypeUtil {
 		allWireValues.putAll(allInputWireValues);
 			
 		allOutputWireValues = new HashMap<Integer, SecretKey[]>();
-		translationTable = new HashMap<Integer, Byte>();
+		translationTable = new HashMap<>();
 			
 		//Create the keys of the non-input wires.
 		createNonInputWireValues(ungarbledGates, allWireValues, globalKeyOffset);
@@ -185,7 +185,7 @@ class FreeXORGarbledBooleanCircuitUtil implements CircuitTypeUtil {
 			
 			//Signal bit is the last bit of k0.
 			byte[] k0 = allWireValues.get(n)[0].getEncoded();
-			translationTable.put(n, (byte) (k0[k0.length-1] & 1));			
+			translationTable.put(n, ((k0[k0.length-1] & 1) == 1) ? true: false);			
 		}
 		
 		//now that we have all keys, we can create the garbled tables.
@@ -456,7 +456,7 @@ class FreeXORGarbledBooleanCircuitUtil implements CircuitTypeUtil {
 	private CircuitCreationValues sampleSeedKeys(BooleanCircuit ungarbledCircuit, PseudorandomGenerator prg, byte[] seed, Map<Integer, SecretKey[]> allWireValues) throws InvalidKeyException {
 		Map<Integer, SecretKey[]> allInputWireValues = new HashMap<Integer, SecretKey[]>();
 		Map<Integer, SecretKey[]> outputGarbledValues = new HashMap<Integer, SecretKey[]>();
-		HashMap<Integer, Byte> translationTable = new HashMap<Integer, Byte>();
+		HashMap<Integer, Boolean> translationTable = new HashMap<>();
 		
 		//Sets the given seed as the prg key.
 		prg.setKey(new SecretKeySpec(seed, ""));
@@ -504,7 +504,7 @@ class FreeXORGarbledBooleanCircuitUtil implements CircuitTypeUtil {
 			
 			//Signal bit is the last bit of k0.
 			byte[] k0 = allWireValues.get(n)[0].getEncoded();
-			translationTable.put(n, (byte) (k0[k0.length-1] & 1));	
+			translationTable.put(n, ((k0[k0.length-1] & 1) == 1 ? true: false));	
 		}
 		
 		return new CircuitCreationValues(allInputWireValues, outputGarbledValues, translationTable);

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuit.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuit.java
@@ -167,14 +167,14 @@ public interface GarbledBooleanCircuit {
      * and needs the translation table as well to complete the construction of the circuit.
      * @return the translation table of the circuit.  
      */
-	public HashMap<Integer, Byte> getTranslationTable();
+	public HashMap<Integer, Boolean> getTranslationTable();
   
 	/**
 	 * Sets the translation table of the circuit. <p>
 	 * This is necessary when the garbled tables where set and we would like to compute the circuit later on. 
 	 * @param translationTable This value should match the garbled tables of the circuit.
 	 */
-	public void setTranslationTable(HashMap<Integer, Byte> translationTable);
+	public void setTranslationTable(HashMap<Integer, Boolean> translationTable);
 	
 	/**
 	 * Returns the input wires' indices of the given party.

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuit.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuit.java
@@ -83,7 +83,7 @@ public interface GarbledBooleanCircuit {
 	 * @param ungarbledInput A map containing the {@code GarbledWire} indices and <b> non garbled</b> value for that index. 
 	 * @param allInputWireValues The map containing both garbled values for each input wire.
 	 */
-	public void setGarbledInputFromUngarbledInput(Map<Integer, Byte> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) ;
+	public void setGarbledInputFromUngarbledInput(Map<Integer, Boolean> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) ;
  
 	/**
 	 * This method computes the circuit if the input has been set. <p>

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitAbs.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitAbs.java
@@ -84,14 +84,14 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
 	}
 	
 	@Override
- 	public void setGarbledInputFromUngarbledInput(Map<Integer, Byte> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) {
+ 	public void setGarbledInputFromUngarbledInput(Map<Integer, Boolean> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) {
   		
   		Map<Integer, GarbledWire> inputs = new HashMap<Integer, GarbledWire>();
   		Set<Integer> keys = ungarbledInput.keySet();
   		
   		//For each wireIndex, fill the map with wire index and garbled input.
   		for (Integer wireIndex : keys) {
-  			inputs.put(wireIndex, new GarbledWire(allInputWireValues.get(wireIndex)[ungarbledInput.get(wireIndex)]));
+  			inputs.put(wireIndex, new GarbledWire(allInputWireValues.get(wireIndex)[(ungarbledInput.get(wireIndex) == true) ?   1 : 0]));
   		}
   		setInputs(inputs);
   	}

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitAbs.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitAbs.java
@@ -72,7 +72,7 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
 	 * privacy and/or correctness will not be preserved. Therefore, we only reveal the signal bit, and the other
 	 * possible value for the wire is not stored on the translation table.
 	 */
-	protected HashMap<Integer, Byte> translationTable;
+	protected HashMap<Integer, Boolean> translationTable;
   	
 	
 	//A map that is used during computation to map a {@code GarbledWire}'s index to the computed and set {@code GarbledWire}.
@@ -107,7 +107,7 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
   	 * @param key to get the signal bit of.
   	 * @return the signal bit of the given key.
   	 */
-  	abstract byte getKeySignalBit(SecretKey key);
+  	abstract boolean getKeySignalBit(SecretKey key);
   	
   	@Override
   	public boolean verify(Map<Integer, SecretKey[]> allInputWireValues){
@@ -124,12 +124,12 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
   			SecretKey zeroValue = outputValues.get(w)[0];
   			SecretKey oneValue = outputValues.get(w)[1];
 
-  			byte signalBit = translationTable.get(w);
-  			byte permutationBitOnZeroWire = getKeySignalBit(zeroValue);
-  			byte permutationBitOnOneWire = getKeySignalBit(oneValue);
-  			byte translatedZeroValue = (byte) (signalBit ^ permutationBitOnZeroWire);
-  			byte translatedOneValue = (byte) (signalBit ^ permutationBitOnOneWire);
-  			if (translatedZeroValue != 0 || translatedOneValue != 1) {
+  			boolean signalBit = translationTable.get(w);
+  			boolean permutationBitOnZeroWire = getKeySignalBit(zeroValue);
+  			boolean permutationBitOnOneWire = getKeySignalBit(oneValue);
+  			boolean translatedZeroValue = (signalBit ^ permutationBitOnZeroWire);
+  			boolean translatedOneValue = (signalBit ^ permutationBitOnOneWire);
+  			if (translatedZeroValue != Boolean.FALSE || translatedOneValue != Boolean.TRUE) {
   				verified = false;
   			}
   		}
@@ -140,7 +140,7 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
   	public Map<Integer, Wire> translate(Map<Integer, GarbledWire> garbledOutput){
   		
 		Map<Integer, Wire> translatedOutput = new HashMap<Integer, Wire>();
-		byte signalBit, permutationBitOnWire, value;
+		boolean signalBit, permutationBitOnWire, value;
 		
 	    //Go through the output wires and translate it using the translation table.
 	    for (int w : outputWireIndices) {
@@ -148,7 +148,7 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
 	    	permutationBitOnWire = garbledOutput.get(w).getSignalBit();
 	      
 	    	//Calculate the resulting value.
-	    	value = (byte) (signalBit ^ permutationBitOnWire);
+	    	value = signalBit ^ permutationBitOnWire;
 	    	
 	    	//Hold the result as a wire.
 	    	Wire translated = new Wire(value);
@@ -227,13 +227,13 @@ abstract class GarbledBooleanCircuitAbs implements GarbledBooleanCircuit{
 	}
   	
 	@Override
-	public HashMap<Integer, Byte> getTranslationTable(){
+	public HashMap<Integer, Boolean> getTranslationTable(){
 	  
 		return translationTable;
 	}
   
 	@Override
-	public void setTranslationTable(HashMap<Integer, Byte> translationTable){
+	public void setTranslationTable(HashMap<Integer, Boolean> translationTable){
 		
 		this.translationTable = translationTable;
 	}

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitExtendedImp.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitExtendedImp.java
@@ -309,14 +309,14 @@ public class GarbledBooleanCircuitExtendedImp implements GarbledBooleanCircuitEx
 	}
   
 	@Override
- 	public void setGarbledInputFromUngarbledInput(Map<Integer, Byte> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) {
+ 	public void setGarbledInputFromUngarbledInput(Map<Integer, Boolean> ungarbledInput, Map<Integer, SecretKey[]> allInputWireValues) {
   		
   		Map<Integer, GarbledWire> inputs = new HashMap<Integer, GarbledWire>();
   		Set<Integer> keys = ungarbledInput.keySet();
   		
   		//For each wire, fill the map with wire number and garbled input.
   		for (Integer wireNumber : keys) {
-  			inputs.put(wireNumber, new GarbledWire(allInputWireValues.get(wireNumber)[ungarbledInput.get(wireNumber)]));
+  			inputs.put(wireNumber, new GarbledWire(allInputWireValues.get(wireNumber)[(ungarbledInput.get(wireNumber) == true) ? 1 : 0]));
   		}
   		setInputs(inputs);
   	}

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitImp.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledBooleanCircuitImp.java
@@ -192,8 +192,10 @@ public class GarbledBooleanCircuitImp extends GarbledBooleanCircuitAbs implement
   		return garbledOutput;
   	}	
   	
-  	byte getKeySignalBit(SecretKey key){
-  		return (byte) ((key.getEncoded()[key.getEncoded().length - 1] & 1) == 0 ? 0 : 1);
+  	boolean getKeySignalBit(SecretKey key){
+  		final byte[] encoded = key.getEncoded();
+		final int length = encoded.length;
+		return ((encoded[length - 1] & 1) == 0) ? false : true;
   	}
   	
   	@Override

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledWire.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledWire.java
@@ -77,13 +77,15 @@ public class GarbledWire implements Serializable{
 	 * We are not returning the initial signal bit that determined which bit to put on each wire as this information cannot be
 	 * recovered (if it could be, we would be able to determine the actual value of a garbled wire and thus it would not be garbled.)<p>
 	 * 
-	 * See <i>Fairplay — A Secure Two-Party Computation System</i> by Dahlia Malkhi, Noam Nisan, Benny Pinkas, and Yaron Sella. 
+	 * See <i>Fairplay ï¿½ A Secure Two-Party Computation System</i> by Dahlia Malkhi, Noam Nisan, Benny Pinkas, and Yaron Sella. 
 	 * Section 4.2 describes in more detail how the signal bit works. </p>
 	 * 
 	 * @return the signal bit. <p>
   	 */
-	public byte getSignalBit() {
-		byte signalBit = (byte) ((valueAndSignalBit.getEncoded()[valueAndSignalBit.getEncoded().length - 1] & 1) == 0 ? 0 : 1);
+	public boolean getSignalBit() {
+		final byte[] encoded = valueAndSignalBit.getEncoded();
+		final byte lastByte = encoded[encoded.length - 1];
+		final boolean signalBit = (lastByte & 1) == 0 ? Boolean.FALSE  : Boolean.TRUE;
 		return signalBit;
 	}
 

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledBooleanCircuitUtil.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledBooleanCircuitUtil.java
@@ -107,7 +107,7 @@ class StandardGarbledBooleanCircuitUtil implements CircuitTypeUtil{
 		Map<Integer, SecretKey[]> allWireValues = new HashMap<Integer, SecretKey[]>();
 		Map<Integer, SecretKey[]> allInputWireValues = null;
 		Map<Integer, SecretKey[]> allOutputWireValues = null;
-		HashMap<Integer, Byte> translationTable = new HashMap<Integer, Byte>();
+		HashMap<Integer, Boolean> translationTable = new HashMap<Integer, Boolean>();
 		Gate[] ungarbledGates = ungarbledCircuit.getGates();
 		
 		//Sample the input keys.
@@ -192,7 +192,7 @@ class StandardGarbledBooleanCircuitUtil implements CircuitTypeUtil{
 	 * @param translationTable A map to fill with the output wires' signal bits.
 	 */
 	private void fillOutputWiresValues(int[] outputWireIndices, Map<Integer, SecretKey[]> allOutputWireValues, Map<Integer, SecretKey[]> allWireValues,
-			Map<Integer, Byte> translationTable) {
+			HashMap<Integer, Boolean> translationTable) {
 		/*
 		 * Add the output wire indices' signal bits to the translation table. For a full understanding on why we chose to 
 		 * implement the translation table this way, see the documentation to the translationTable field of
@@ -201,7 +201,7 @@ class StandardGarbledBooleanCircuitUtil implements CircuitTypeUtil{
 		for (int n : outputWireIndices) {
 			//Signal bit is the last bit of k0.
 			byte[] k0 = allWireValues.get(n)[0].getEncoded();
-			translationTable.put(n, (byte) (k0[k0.length-1] & 1));	
+			translationTable.put(n, (k0[k0.length-1] & 1) == 0 ? false : true);	
 			
 			//Add both values of output wire to the allOutputWireValues Map that was passed as a parameter.
 			allOutputWireValues.put(n, allWireValues.get(n));
@@ -279,7 +279,7 @@ class StandardGarbledBooleanCircuitUtil implements CircuitTypeUtil{
 		Map<Integer, SecretKey[]> allInputWireValues = new HashMap<Integer, SecretKey[]>();
 		Map<Integer, SecretKey[]> outputGarbledValues = new HashMap<Integer, SecretKey[]>();
 		
-		HashMap<Integer, Byte> translationTable = new HashMap<Integer, Byte>();
+		HashMap<Integer, Boolean> translationTable = new HashMap<>();
 		
 		//Sets the given seed as the prg key.
 		prg.setKey(new SecretKeySpec(seed, ""));

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledGate.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledGate.java
@@ -135,7 +135,7 @@ class StandardGarbledGate implements GarbledGate {
 		  		/*
 	    		 * The signal bits tell us the position on the garbled truth table for the given row of an ungarbled truth table.
 	    		 * The signal bit of wire i is the last bit of wire i's k0. 
-	    		 * See Fairplay — A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
+	    		 * See Fairplay ï¿½ A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
 	    		 */
 		  		byte[] k0 = allWireValues.get(inputWireIndices[i])[0].getEncoded();
 		  		byte signalBit =  (byte) (k0[k0.length-1] & 1);
@@ -216,7 +216,7 @@ class StandardGarbledGate implements GarbledGate {
 			keysToDecryptOn[i] = wire.getValueAndSignalBit();
 		  
 			// Put the signal bits of the input wire values into the tweak.
-			tweak.putInt(wire.getSignalBit());
+			tweak.putInt(wire.getSignalBit() ? 1 : 0);
 		}
 		
 		mes.setKey(mes.generateMultiKey(keysToDecryptOn));
@@ -244,8 +244,10 @@ class StandardGarbledGate implements GarbledGate {
 	protected int getIndexToDecrypt(Map<Integer, GarbledWire> computedWires) {
 		int garbledTableIndex = 0;
 		int numberOfInputs = inputWireIndices.length;
-		for (int i = numberOfInputs - 1, j = 0; j < numberOfInputs; i--, j++) {
-			garbledTableIndex += computedWires.get(inputWireIndices[i]).getSignalBit() * Math.pow(2, j);
+		for (int i = numberOfInputs - 1, j = 0; j < numberOfInputs; i--, j++) {			
+			final GarbledWire garbledWire = computedWires.get(inputWireIndices[i]);
+			assert (garbledWire != null);
+			garbledTableIndex += (garbledWire.getSignalBit() ? 1 : 0) * Math.pow(2, j);
 		}
 		return garbledTableIndex;
 	}

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardRowReductionGarbledGate.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardRowReductionGarbledGate.java
@@ -163,7 +163,7 @@ class StandardRowReductionGarbledGate extends StandardGarbledGate{
 			}
 			kdfBytes.putInt(gateNumber);
 			for (int i = 0; i < numberOfInputs; i++) {
-				kdfBytes.putInt(computedWires.get(inputWireIndices[i]).getSignalBit());
+				kdfBytes.putInt(computedWires.get(inputWireIndices[i]).getSignalBit() ? 1 : 0);
 			}
 			wireValue = kdf.deriveKey(kdfBytes.array(), 0, mes.getCipherSize()*numberOfInputs +16, mes.getCipherSize());
 			


### PR DESCRIPTION
The API confused me when I saw Bytes being passed around.
It's only Booleans, no?  If so, we better be semantically correct and
use Booleans.
This modifications compiles, but I don't know whether anything broke.

I guess a few iterations need to be made until this is a perfect patch.
For example, the boolsToBytes could probably be moved to a more central place.
Documentation probably also needs to be updated, but I haven't checked.