### PR TITLE
Allow repeated setup and teardown of communications without JVM restart

### DIFF
--- a/src/java/edu/biu/scapi/comm/CommunicationSetup.java
+++ b/src/java/edu/biu/scapi/comm/CommunicationSetup.java
@@ -405,12 +405,15 @@ public class CommunicationSetup implements TimeoutObserver{
 			
 			//sets the flag of the thread to stopped. This will make the run function of the thread to terminate if it has not finished yet.
 			thread.stopConnecting();
+            thread.interrupt();
 			
 		}	
 		
 		//further stop the listening thread if it still runs. Similarly, it sets the flag of the listening thread to stopped.
-		if(listeningThread!=null)
-			listeningThread.stopConnecting();
+		if(listeningThread!=null) {
+            listeningThread.stopConnecting();
+            listeningThread.interrupt();
+        }
 	}
 	
 }


### PR DESCRIPTION
This fixes https://github.com/cryptobiu/scapi/issues/41.
- Interrupt threads from `CommunicationSetup` in `timeoutOccured`
- Close `ServerSocketChannel` from `ListeningThread` when interrupted using try...finally block
