### PR TITLE
Fixed the filename of OTExtensionMaliciousCommonInterface.h

### DIFF
--- a/src/jni/MaliciousOtExtensionJavaInterface/OTExtensionMaliciousReceiverInterface.h
+++ b/src/jni/MaliciousOtExtensionJavaInterface/OTExtensionMaliciousReceiverInterface.h
@@ -15,7 +15,7 @@
 #include <iomanip>
 #include <string>
 
-#include "OtExtensionMaliciousCommonInterface.h"
+#include "OTExtensionMaliciousCommonInterface.h"
 
 namespace maliciousot {
 

--- a/src/jni/MaliciousOtExtensionJavaInterface/OTExtensionMaliciousSenderInterface.h
+++ b/src/jni/MaliciousOtExtensionJavaInterface/OTExtensionMaliciousSenderInterface.h
@@ -15,7 +15,7 @@
 #include <iomanip>
 #include <string>
 
-#include "OtExtensionMaliciousCommonInterface.h"
+#include "OTExtensionMaliciousCommonInterface.h"
 
 namespace maliciousot {
 


### PR DESCRIPTION
They were not capitalized.  This leads to issues on a case sensitive
file system.