### PR TITLE
Change char encoding to remove javadoc errors

### DIFF
--- a/src/java/edu/biu/scapi/circuits/circuit/Gate.java
+++ b/src/java/edu/biu/scapi/circuits/circuit/Gate.java
@@ -167,7 +167,7 @@ public class Gate {
 	private int calculateIndexOfTruthTable(Map<Integer, Wire> computedWires) {
   
 		/*
-		 * Since a truth table’s order is the order of binary counting, the index of a desired row can be calculated as follows: 
+		 * Since a truth tables order is the order of binary counting, the index of a desired row can be calculated as follows: 
 		 * For a truth table with L inputs whose input columns are labeled aL...ai...a2,a1, 
 		 * the output index for a given input set is given by: summation from 0 to L : ai *2^i. 
 		 * This is calculated below:

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledWire.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/GarbledWire.java
@@ -77,7 +77,7 @@ public class GarbledWire implements Serializable{
 	 * We are not returning the initial signal bit that determined which bit to put on each wire as this information cannot be
 	 * recovered (if it could be, we would be able to determine the actual value of a garbled wire and thus it would not be garbled.)<p>
 	 * 
-	 * See <i>Fairplay — A Secure Two-Party Computation System</i> by Dahlia Malkhi, Noam Nisan, Benny Pinkas, and Yaron Sella. 
+	 * See <i>Fairplay - A Secure Two-Party Computation System</i> by Dahlia Malkhi, Noam Nisan, Benny Pinkas, and Yaron Sella. 
 	 * Section 4.2 describes in more detail how the signal bit works. </p>
 	 * 
 	 * @return the signal bit. <p>

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/MinimizeAESSetKeyGarbledGate.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/MinimizeAESSetKeyGarbledGate.java
@@ -109,7 +109,7 @@ class MinimizeAESSetKeyGarbledGate extends StandardGarbledGate {
 	    		byte input = (byte) (((rowOfTruthTable & j) == 0) ? 0 : 1);
 	    		/*
 	    		 * The signal bits tell us the position on the garbled truth table for the given row of an ungarbled truth table. 
-	    		 * See Fairplay — A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
+	    		 * See Fairplay - A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
 	    		 */
 	    		byte[] k0 = allWireValues.get(inputWireIndices[i])[0].getEncoded();
 		  		byte signalBit =  (byte) (k0[k0.length-1] & 1);

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/MinimizeAESSetKeyRowReductionGate.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/MinimizeAESSetKeyRowReductionGate.java
@@ -111,7 +111,7 @@ class MinimizeAESSetKeyRowReductionGate extends StandardRowReductionGarbledGate 
 	    		/*
 	    		 * The signal bits tell us the position on the garbled truth table for the given row of an ungarbled truth table. 
 	    		 * The signal bit os the last bit of k0.
-	    		 * See Fairplay — A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
+	    		 * See Fairplay - A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
 	    		 */
 	    		byte[] k0 = allWireValues.get(inputWireIndices[i])[0].getEncoded();
 		  		byte signalBit =  (byte) (k0[k0.length-1] & 1);

--- a/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledGate.java
+++ b/src/java/edu/biu/scapi/circuits/garbledCircuit/StandardGarbledGate.java
@@ -135,7 +135,7 @@ class StandardGarbledGate implements GarbledGate {
 		  		/*
 	    		 * The signal bits tell us the position on the garbled truth table for the given row of an ungarbled truth table.
 	    		 * The signal bit of wire i is the last bit of wire i's k0. 
-	    		 * See Fairplay — A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
+	    		 * See Fairplay - A Secure Two-Party Computation System by Dahlia Malkhi, Noam Nisan1, Benny Pinkas, and Yaron Sella for more on signal bits.
 	    		 */
 		  		byte[] k0 = allWireValues.get(inputWireIndices[i])[0].getEncoded();
 		  		byte signalBit =  (byte) (k0[k0.length-1] & 1);

--- a/src/java/edu/biu/scapi/comm/EstablishedConnections.java
+++ b/src/java/edu/biu/scapi/comm/EstablishedConnections.java
@@ -43,9 +43,9 @@ import edu.biu.scapi.generals.Logging;
  * The CommunicationSetup class holds a container of type EstablishedConnections that keeps track of the connections (channels) 
  * as they are being established. This container has a number of channels that can be in different states.
  * EstablishedConnections has regular operations of containers such as add and remove. It also has logical operations such as areAllConnected.
- * At the end of the “prepare for communication” method, the calling application receives a map of connections in the EstablishedConnections 
+ * At the end of the prepare for communication method, the calling application receives a map of connections in the EstablishedConnections 
  * object held by the CommunicationSetup. At this stage, all the channels in EstablishedConnections object need to be in READY state. 
- * It is possible that this object will be null if the “prepare for communication” did not succeed. 
+ * It is possible that this object will be null if the prepare for communication did not succeed. 
  * The key to the map is an object of type InetSocketAddress that holds the IP and the port. Since the IP and port are unique, 
  * they define a unique InetSocketAddress that can serve as a key to the map.   
 

--- a/src/java/edu/biu/scapi/comm/KeyExchangeProtocol.java
+++ b/src/java/edu/biu/scapi/comm/KeyExchangeProtocol.java
@@ -29,9 +29,9 @@
 /**
  * Key Exchange Protocols are implemented using the Strategy design pattern so that different protocols can be chosen by the application. 
  * An instance of the chosen concrete class is passed to the CommunicationSetup. We will currently implement three options:
- *   •	Init key, in this protocol each party has already received as input the shared keys.
- *   •	Plain Diffie-Hellman Key Exchange.
- *   •	Universally Composable Diffie-Hellman.
+ *   Init key, in this protocol each party has already received as input the shared keys.
+ *   Plain Diffie-Hellman Key Exchange.
+ *   Universally Composable Diffie-Hellman.
  * Since Key Exchange Protocols are a type of Protocol, they also implement the Protocol Interface. 
  */
 package edu.biu.scapi.comm;

--- a/src/java/edu/biu/scapi/comm/Protocol.java
+++ b/src/java/edu/biu/scapi/comm/Protocol.java
@@ -34,9 +34,9 @@
  * Created by LabTest
  *
  * Any algorithm that needs to be run by an application as a protocol has to implement the Protocol Interface. It has three methods:
- * •	start(ProtocolInput); initialize input
- * •	run(); run the protocol
- * •	getOutput(); returns an object of type Output.
+ * start(ProtocolInput); initialize input
+ * run(); run the protocol
+ * getOutput(); returns an object of type Output.
  * Any necessary data has to be provided to the concrete protocol in the start() function as an object of type ProtocolInput. 
  * This data will be used inside the methods. Each protocol may have a specific type of ProtocolInput. 
  * Having the data passed to the protocol object in the start() function allows for repeated runs of the protocol such that in between 

--- a/src/java/edu/biu/scapi/comm/twoPartyComm/QueueChannel.java
+++ b/src/java/edu/biu/scapi/comm/twoPartyComm/QueueChannel.java
@@ -53,10 +53,10 @@ import edu.biu.scapi.comm.Channel;
  * In fact, the sender does not need to know anything about the receiver; nor does the receiver need to know anything 
  * about the sender. The sender and the receiver need to know only which message format and which destination to use.
  * In this respect, messaging differs from tightly coupled technologies, such as Remote Method Invocation (RMI), 
- * which require an application to know a remote application’s methods.<p>
+ * which require an application to know a remote applications methods.<p>
  * 
  * In order to enforce the right usage of the Channel class we will restrict the ability to instantiate one, 
- * only to classes within the Communication Layer’s package. This means that the constructor of the channel will be 
+ * only to classes within the Communication Layers package. This means that the constructor of the channel will be 
  * unreachable from another package. However, the send, receive and close functions will be declared public, therefore 
  * allowing anyone holding a channel to be able to use them.<p>
  * 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/coinTossing/CTSemiSimulatablePartyOne.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/coinTossing/CTSemiSimulatablePartyOne.java
@@ -41,7 +41,7 @@ import edu.biu.scapi.securityLevel.PerfectlyHidingCmt;
 
 /**
  * This class plays as party one of coin tossing protocol which tosses a string.<p>
- * This protocol is fully secure (with simulation) when P1 is corrupted and fulfills a definition of “pseudorandomness” when P2 is corrupted. <p>
+ * This protocol is fully secure (with simulation) when P1 is corrupted and fulfills a definition of "pseudorandomness" when P2 is corrupted. <p>
  * 
  * This protocol uses any perfectly-hiding commitment scheme (e.g., COMMIT_PEDERSEN,  COMMIT_HASH_PEDERSEN, COMMIT_HASH) 
  * and any perfectly-binding commitment scheme (e.g., COMMIT_ELGAMAL). <P>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/coinTossing/CTSemiSimulatablePartyTwo.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/coinTossing/CTSemiSimulatablePartyTwo.java
@@ -41,7 +41,7 @@ import edu.biu.scapi.securityLevel.PerfectlyHidingCmt;
 
 /**
  * This class plays as party two of coin tossing protocol which tosses a string.<p>
- * This protocol is fully secure (with simulation) when P1 is corrupted and fulfills a definition of “pseudorandomness” when P2 is corrupted. <p>
+ * This protocol is fully secure (with simulation) when P1 is corrupted and fulfills a definition of "pseudorandomness" when P2 is corrupted. <p>
  * 
  * This protocol uses any perfectly-hiding commitment scheme (e.g., COMMIT_PEDERSEN,  COMMIT_HASH_PEDERSEN, COMMIT_HASH) 
  * and any perfectly-binding commitment scheme (e.g., COMMIT_ELGAMAL). <P>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalOnByteArrayReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalOnByteArrayReceiver.java
@@ -111,9 +111,9 @@ public class CmtElGamalOnByteArrayReceiver extends CmtElGamalReceiverCore implem
 	/**
 	 * Proccesses the decommitment phase.<p>
 	 * "IF NOT<p>
-	 *	•	u=g^r <p>
-	 *	•	v = h^r * x<p>
-	 *	•	x in G<p>
+	 *		u=g^r <p>
+	 *		v = h^r * x<p>
+	 *		x in G<p>
 	 *		OUTPUT REJ<p>
 	 *	ELSE<p>
 	 *	    OUTPUT ACC and value x"<p>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalOnGroupElementReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalOnGroupElementReceiver.java
@@ -103,9 +103,9 @@ public class CmtElGamalOnGroupElementReceiver extends CmtElGamalReceiverCore imp
 	/**
 	 * Proccesses the decommitment phase.<p>
 	 * "IF NOT<p>
-	 *	•	u=g^r <p>
-	 *	•	v = h^r * x<p>
-	 *	•	x in G<p>
+	 *		u=g^r <p>
+	 *		v = h^r * x<p>
+	 *		x in G<p>
 	 *		OUTPUT REJ<p>
 	 *	ELSE<p>
 	 *	    OUTPUT ACC and value x"<p>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalReceiverCore.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/elGamal/CmtElGamalReceiverCore.java
@@ -66,11 +66,11 @@ public abstract class CmtElGamalReceiverCore implements CmtReceiver{
 	 *		WAIT for (r, x)  from C
 	 *		Let c = (h,u,v); if not of this format, output REJ
 	 *		IF NOT
-	 *		•	VALID_PARAMS(G,q,g), AND
-	 *		•	h <-G, AND
-	 *		•	u=g^r 
-	 *		•	v = h^r * x
-	 *		•	x in G
+	 *			VALID_PARAMS(G,q,g), AND
+	 *			h <-G, AND
+	 *			u=g^r 
+	 *			v = h^r * x
+	 *			x in G
 	 *		      OUTPUT REJ
 	 *		ELSE
 	 *		      OUTPUT ACC and value x"
@@ -184,9 +184,9 @@ public abstract class CmtElGamalReceiverCore implements CmtReceiver{
 	 * "WAIT for (r, x)  from C<p>
 	 *	Let c = (h,u,v); if not of this format, output REJ<p>
 	 *	IF NOT<p>
-	 *	•	u=g^r <p>
-	 *	•	v = h^r * x<p>
-	 *	•	x in G<p>
+	 *		u=g^r <p>
+	 *		v = h^r * x<p>
+	 *		x in G<p>
 	 *		OUTPUT REJ<p>
 	 *	ELSE<p>
 	 *	    OUTPUT ACC and value x"

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/simpleHash/CmtSimpleHashReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/commitmentScheme/simpleHash/CmtSimpleHashReceiver.java
@@ -64,8 +64,8 @@ public class CmtSimpleHashReceiver implements CmtReceiver, SecureCommit {
 	 *	Decommit phase
 	 *		WAIT for (r, x)  from C
 	 *		IF NOT
-	 *		•	c = H(r,x), AND
-	 *		•	x <- {0, 1}^t
+	 *			c = H(r,x), AND
+	 *			x <- {0, 1}^t
 	 *		      OUTPUT REJ
 	 *		ELSE
 	 *		      OUTPUT ACC and value x"	 
@@ -131,8 +131,8 @@ public class CmtSimpleHashReceiver implements CmtReceiver, SecureCommit {
 	 * Run the decommit phase of the protocol:
 	 * "WAIT for (r, x)  from C
 	 *	IF NOT
-	 *	•	c = H(r,x), AND
-	 *	•	x <- {0, 1}^t
+	 *		c = H(r,x), AND
+	 *		x <- {0, 1}^t
 	 *		OUTPUT REJ
 	 *	ELSE
 	 *	  	OUTPUT ACC and value x".

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimDDHOnByteArrayReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimDDHOnByteArrayReceiver.java
@@ -178,8 +178,8 @@ public class OTFullSimDDHOnByteArrayReceiver implements OTReceiver, Malicious, S
 	 *	SEND (g,h) to S<p>
 	 *	WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *	IF  NOT<p>
-	 *	•	u0, u1 in G, AND<p>
-	 *	•	c0, c1 are binary strings of the same length<p>
+	 *		u0, u1 in G, AND<p>
+	 *		c0, c1 are binary strings of the same length<p>
 	 *		   REPORT ERROR<p>
 	 *	OUTPUT  xSigma = cSigma XOR KDF(|cSigma|,(uSigma)^r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimDDHOnGroupElementReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimDDHOnGroupElementReceiver.java
@@ -172,7 +172,7 @@ public class OTFullSimDDHOnGroupElementReceiver implements OTReceiver, Malicious
 	 *		SEND (g,h) to S<p>
 	 *		WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1, c0, c1 in G<p>
+	 *			u0, u1, c0, c1 in G<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma * (uSigma)^(-r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimReceiverTransferUtilAbs.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulation/OTFullSimReceiverTransferUtilAbs.java
@@ -77,13 +77,13 @@ public abstract class OTFullSimReceiverTransferUtilAbs {
 	 *		WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *		In ByteArray scenario:<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1 in G, AND<p>
-	 *		•	c0, c1 are binary strings of the same length<p>
+	 *			u0, u1 in G, AND<p>
+	 *			c0, c1 are binary strings of the same length<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma XOR KDF(|cSigma|,(uSigma)^r)<p>
 	 *		In GroupElement scenario:<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1, c0, c1 in G<p>
+	 *			u0, u1, c0, c1 in G<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma * (uSigma)^(-r)<p>
 	 * This is the transfer stage of OT protocol which can be called several times in parallel.<p>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulationROM/OTFullSimROMDDHOnByteArrayReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulationROM/OTFullSimROMDDHOnByteArrayReceiver.java
@@ -186,8 +186,8 @@ public class OTFullSimROMDDHOnByteArrayReceiver implements OTReceiver, Malicious
 	 *		SEND (g,h) to S<p>
 	 *		WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1 in G, AND<p>
-	 *		•	c0, c1 are binary strings of the same length<p>
+	 *			u0, u1 in G, AND<p>
+	 *			c0, c1 are binary strings of the same length<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma XOR KDF(|cSigma|,(uSigma)^r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulationROM/OTFullSimROMDDHOnGroupElementReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/fullSimulationROM/OTFullSimROMDDHOnGroupElementReceiver.java
@@ -180,7 +180,7 @@ public class OTFullSimROMDDHOnGroupElementReceiver implements OTReceiver, Malici
 	 *		SEND (g,h) to S<p>
 	 *		WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1, c0, c1 in G<p>
+	 *			u0, u1, c0, c1 in G<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma * (uSigma)^(-r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/oneSidedSimulation/OTOneSidedSimDDHOnByteArraySender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/oneSidedSimulation/OTOneSidedSimDDHOnByteArraySender.java
@@ -93,8 +93,8 @@ public class OTOneSidedSimDDHOnByteArraySender extends OTOneSidedSimDDHSenderAbs
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	c0 = x0 XOR KDF(|x0|,k0)
-	 *		•	c1 = x1 XOR KDF(|x1|,k1)"
+	 *			c0 = x0 XOR KDF(|x0|,k0)
+	 *			c1 = x1 XOR KDF(|x1|,k1)"
 	 * @param  iput NUST be an instance of OTSOnByteArrayInput.
 	 * @param w0
 	 * @param w1

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/oneSidedSimulation/OTOneSidedSimDDHOnGroupElementSender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/oneSidedSimulation/OTOneSidedSimDDHOnGroupElementSender.java
@@ -77,8 +77,8 @@ public class OTOneSidedSimDDHOnGroupElementSender extends OTOneSidedSimDDHSender
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	c0 = x0 * k0
-	 *		•	c1 = x1 * k1"
+	 *			c0 = x0 * k0
+	 *			c1 = x1 * k1"
 	 * @param input MUST be OTSOnGroupElementInput.
 	 * @param w0
 	 * @param w1

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchOnByteArraySender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchOnByteArraySender.java
@@ -79,8 +79,8 @@ public class OTSemiHonestDDHBatchOnByteArraySender extends OTSemiHonestDDHBatchS
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	v0 = x0 XOR KDF(|x0|,k0) 
-	 *		•	v1 = x1 XOR KDF(|x1|,k1)"
+	 *			v0 = x0 XOR KDF(|x0|,k0) 
+	 *			v1 = x1 XOR KDF(|x1|,k1)"
 	 * @param input MUST be an instance of OTSBatchOnByteArrayInput
 	 * @param k1Array
 	 * @param k0Array 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchOnGroupElementSender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchOnGroupElementSender.java
@@ -68,8 +68,8 @@ public class OTSemiHonestDDHBatchOnGroupElementSender extends OTSemiHonestDDHBat
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *	•   vi0 = xi0 * ki0
-	 *	•	vi1 = xi1 * ki1""
+	 *	  vi0 = xi0 * ki0
+	 *  	vi1 = xi1 * ki1""
 	 * @param input MUST be an instance of OTSBatchOnGroupElementInput
 	 * @param k1Arr 
 	 * @param k0Arr 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchReceiverAbs.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/otBatch/semiHonest/OTSemiHonestDDHBatchReceiverAbs.java
@@ -62,7 +62,7 @@ import edu.biu.scapi.tools.Factories.DlogGroupFactory;
 abstract class OTSemiHonestDDHBatchReceiverAbs implements OTBatchReceiver{
 	/*	
 	 	This class runs the following protocol:
-		 	For every i=1,…m, SAMPLE random values alphaI <- Zq and hi <- G 
+		 	For every i=1,...,m, SAMPLE random values alphaI <- Zq and hi <- G 
 			For every i=1,...,m, COMPUTE hi0,hi1 as follows:
 			1.	If SigmaI = 0 then hi0 = g^alphaI  and hi1=hi
 			2.	If SigmaI = 1 then hi0=hi and hi1 = g^alphaI 
@@ -135,7 +135,7 @@ abstract class OTSemiHonestDDHBatchReceiverAbs implements OTBatchReceiver{
 	
 	/**
 	 * Runs the transfer phase of the OT protocol.<p>
-	 * "For every i=1,…m, SAMPLE random values alphaI <- Zq and hi <- G <p>
+	 * "For every i=1,...,m, SAMPLE random values alphaI <- Zq and hi <- G <p>
 	 *	For every i=1,...,m, COMPUTE hi0,hi1 as follows:<p>
 	 *	1.	If SigmaI = 0 then hi0 = g^alphaI  and hi1=hi<p>
 	 *	2.	If SigmaI = 1 then hi0=hi and hi1 = g^alphaI <p>
@@ -164,7 +164,7 @@ abstract class OTSemiHonestDDHBatchReceiverAbs implements OTBatchReceiver{
 			
 		}
 		
-		//For every i=1,…m, SAMPLE random values alphaI <- Zq.
+		//For every i=1,...,m, SAMPLE random values alphaI <- Zq.
 		ArrayList<BigInteger> alphaArr = new ArrayList<BigInteger>();
 		ArrayList<GroupElement> hArr = new ArrayList<GroupElement>();
 		for (int i=0; i<size; i++){

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/privacyOnly/OTPrivacyOnlyDDHOnByteArraySender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/privacyOnly/OTPrivacyOnlyDDHOnByteArraySender.java
@@ -82,8 +82,8 @@ public class OTPrivacyOnlyDDHOnByteArraySender extends OTPrivacyOnlyDDHSenderAbs
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	c0 = x0 XOR KDF(|x0|,k0)
-	 *		•	c1 = x1 XOR KDF(|x1|,k1)"
+	 *			c0 = x0 XOR KDF(|x0|,k0)
+	 *			c1 = x1 XOR KDF(|x1|,k1)"
 	 * @param input MUST be OTSOnByteArrayInput with x0, x1 of the same arbitrary length.
 	 * @param k1 
 	 * @param k0 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/privacyOnly/OTPrivacyOnlyDDHOnGroupElementSender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/privacyOnly/OTPrivacyOnlyDDHOnGroupElementSender.java
@@ -71,8 +71,8 @@ public class OTPrivacyOnlyDDHOnGroupElementSender extends OTPrivacyOnlyDDHSender
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	c0 = x0 * k0
-	 *		•	c1 = x1 * k1"
+	 *			c0 = x0 * k0
+	 *			c1 = x1 * k1"
 	 * @param input MUST be OTSOnGroupElementInput.
 	 * @param k1 
 	 * @param k0 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/semiHonest/OTSemiHonestDDHOnByteArraySender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/semiHonest/OTSemiHonestDDHOnByteArraySender.java
@@ -77,8 +77,8 @@ public class OTSemiHonestDDHOnByteArraySender extends OTSemiHonestDDHSenderAbs i
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	v0 = x0 XOR KDF(|x0|,k0) 
-	 *		•	v1 = x1 XOR KDF(|x1|,k1)"
+	 *			v0 = x0 XOR KDF(|x0|,k0) 
+	 *			v1 = x1 XOR KDF(|x1|,k1)"
 	 * @param input MUST be an instance of OTSOnByteArrayInput
 	 * @param k1 
 	 * @param k0 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/semiHonest/OTSemiHonestDDHOnGroupElementSender.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/semiHonest/OTSemiHonestDDHOnGroupElementSender.java
@@ -65,8 +65,8 @@ public class OTSemiHonestDDHOnGroupElementSender extends OTSemiHonestDDHSenderAb
 	/**
 	 * Runs the following lines from the protocol:
 	 * "COMPUTE:
-	 *		•	v0 = x0 * k0
-	 *		•	v1 = x1 * k1"
+	 *			v0 = x0 * k0
+	 *			v1 = x1 * k1"
 	 * @param input MUST be an instance of OTSOnGroupElementInput
 	 * @param k1 
 	 * @param k0 

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/uc/OTUCDDHOnByteArrayReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/uc/OTUCDDHOnByteArrayReceiver.java
@@ -103,8 +103,8 @@ public class OTUCDDHOnByteArrayReceiver implements OTReceiver, Malicious, UC{
 	 *	SEND (g,h) to S<p>
 	 *	WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *	IF  NOT<p>
-	 *	•	u0, u1 in G, AND<p>
-	 *	•	c0, c1 are binary strings of the same length<p>
+	 *		u0, u1 in G, AND<p>
+	 *		c0, c1 are binary strings of the same length<p>
 	 *		   REPORT ERROR<p>
 	 *	OUTPUT  xSigma = cSigma XOR KDF(|cSigma|,(uSigma)^r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/ot/uc/OTUCDDHOnGroupElementReceiver.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/ot/uc/OTUCDDHOnGroupElementReceiver.java
@@ -100,7 +100,7 @@ public class OTUCDDHOnGroupElementReceiver implements OTReceiver, Malicious, UC{
 	 *		SEND (g,h) to S<p>
 	 *		WAIT for messages (u0,c0) and (u1,c1) from S<p>
 	 *		IF  NOT<p>
-	 *		•	u0, u1, c0, c1 in G<p>
+	 *			u0, u1, c0, c1 in G<p>
 	 *		      REPORT ERROR<p>
 	 *		OUTPUT  xSigma = cSigma * (uSigma)^(-r)<p>
 	 */

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/and/SigmaANDProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/and/SigmaANDProverComputation.java
@@ -49,8 +49,8 @@ public class SigmaANDProverComputation implements SigmaProverComputation{
 
 	/*	
 	  This class computes the following calculations:
-		  	COMPUTE all first prover messages a1,…,am
-			COMPUTE all second prover messages z1,…,zm
+        COMPUTE all first prover messages a1,...,am
+        COMPUTE all second prover messages z1,...,zm
 	*/
 	
 	private ArrayList<SigmaProverComputation> provers;	// Underlying Sigma protocol's provers to the AND calculation.
@@ -107,9 +107,9 @@ public class SigmaANDProverComputation implements SigmaProverComputation{
 
 	/**
 	 * Computes the first message the protocol.<p>
-	 * "COMPUTE all first prover messages a1,…,am". 
+	 * "COMPUTE all first prover messages a1,...,am". 
 	 * @param input MUST be an instance of SigmaANDInput.
-	 * @return SigmaMultipleMsg contains a1, …, am.  
+	 * @return SigmaMultipleMsg contains a1, ..., am.  
 	 * @throws IllegalArgumentException if input is not an instance of SigmaANDInput.
 	 * @throws IllegalArgumentException if the number of given inputs is different from the number of underlying provers.
 	 */
@@ -132,9 +132,9 @@ public class SigmaANDProverComputation implements SigmaProverComputation{
 
 	/**
 	 * Computes the second message of the protocol.<p>
-	 * "COMPUTE all second prover messages z1,…,zm".
+	 * "COMPUTE all second prover messages z1,...,zm".
 	 * @param challenge
-	 * @return SigmaMultipleMsg contains z1, …, zm.
+	 * @return SigmaMultipleMsg contains z1, ..., zm.
 	 * @throws CheatAttemptException if the received challenge's length is not equal to the soundness parameter.
 	 */
 	public SigmaProtocolMsg computeSecondMsg(byte[] challenge) throws CheatAttemptException {

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/and/SigmaANDSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/and/SigmaANDSimulator.java
@@ -47,9 +47,9 @@ import edu.biu.scapi.interactiveMidProtocols.sigmaProtocol.utility.SigmaSimulato
 public class SigmaANDSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
-		  	SAMPLE random values z1 <- ZN, z2 <- Z*n, z3 <- Z*n
-			COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N’ AND a2 = c2^z1/(z3^N*c3^e) mod N’
-			OUTPUT (a,e,z) where a = (a1,a2) AND z=(z1,z2,z3)
+        SAMPLE random values z1 <- ZN, z2 <- Z*n, z3 <- Z*n
+        COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N' AND a2 = c2^z1/(z3^N*c3^e) mod N'
+        OUTPUT (a,e,z) where a = (a1,a2) AND z=(z1,z2,z3)
 
 	*/
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueProverComputation.java
@@ -59,12 +59,12 @@ public class SigmaCramerShoupEncryptedValueProverComputation implements SigmaPro
 	/*	
 	  This class uses an instance of SigmaDHExtendedProver with:
 	  
-	  		•	Common DlogGroup
-			•	Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
-			•	P’s private input: r
+        Common DlogGroup
+          Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
+          P-s private input: r
 
 	*/	 
-	
+
 	private SigmaDHExtendedProverComputation sigmaDH;	//underlying SigmaDHExtendedProver to use.
 	private DlogGroup dlog;					//We save the dlog because we need it to calculate the input for the underlying Sigma prover.
 	private CryptographicHash hash;			//Underlying hash function that used in the CramerShoup cryptosystem.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueSimulator.java
@@ -55,8 +55,8 @@ public class SigmaCramerShoupEncryptedValueSimulator implements SigmaSimulator{
 	
 	/*	
 	  This class uses an instance of SigmaDHExtendedSimulator with:
-	  	•	Common DlogGroup
-	  	•	Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
+        Common DlogGroup
+        Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
 	*/
 	
 	private SigmaDHExtendedSimulator dhSim; 	//underlying SigmaDHExtendedSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/cramerShoupEncryptedValue/SigmaCramerShoupEncryptedValueVerifierComputation.java
@@ -58,8 +58,8 @@ public class SigmaCramerShoupEncryptedValueVerifierComputation implements SigmaV
 	/*	
 	  This class uses an instance of SigmaDHExtendedVerifier with:
 	  
-	  		•	Common DlogGroup
-			•	Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
+        Common DlogGroup
+        Common input: (g1,g2,g3,g4,h1,h2,h3,h4) = (g1,g2,h,cd^w,u1,u2,e/x,v)
 	*/	
 	
 	private SigmaDHExtendedVerifierComputation sigmaDH;		//underlying SigmaDHExtendedVerifier to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueProverComputation.java
@@ -54,8 +54,8 @@ public class SigmaDJEncryptedValueProverComputation implements SigmaProverComput
 
 	/*	
 	  This class uses an instance of SigmaDamgardJurikEncryptedZeroProver with:
-	  	•	Common input: (n,c’) where c’=c*(1+n)^(-x) mod N'
-		•	P’s private input: a value r <- Zq such that c’=r^N mod N’.
+        Common input: (n,c') where c'=c*(1+n)^(-x) mod N'
+        P's private input: a value r <- Zq such that c'=r^N mod N'.
 	*/	 
 	
 	private SigmaDJEncryptedZeroProverComputation sigmaDamgardJurik;	//underlying SigmaDamgardJurikProver to use.
@@ -114,7 +114,7 @@ public class SigmaDJEncryptedValueProverComputation implements SigmaProverComput
 	 */
 	public SigmaProtocolMsg computeFirstMsg(SigmaProverInput in) {
 		/*
-		 * Converts the input (n, c, x, r) to (n, c', r) where c’ = c*(1+n)^(-x) mod N'.
+		 * Converts the input (n, c, x, r) to (n, c', r) where c' = c*(1+n)^(-x) mod N'.
 		 */
 		if (!(in instanceof SigmaDJEncryptedValueProverInput)){
 			throw new IllegalArgumentException("the given input must be an instance of SigmaDJEncryptedValueProverInput");

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueSimulator.java
@@ -52,7 +52,7 @@ public class SigmaDJEncryptedValueSimulator implements SigmaSimulator{
 
 	/*	
 	  This class uses an instance of SigmaDamgardJurikEncryptedZeroSimulator with:
-	  	•	Common input: (n,c’) where c’=c*(1+n)^(-x) mod N'
+	  		Common input: (n,c') where c'=c*(1+n)^(-x) mod N'
 	*/
 	
 	private SigmaDJEncryptedZeroSimulator djSim; // Underlying SigmaDamgardJurikEncryptedZeroSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedValue/SigmaDJEncryptedValueVerifierComputation.java
@@ -52,7 +52,7 @@ public class SigmaDJEncryptedValueVerifierComputation implements SigmaVerifierCo
 
 	/*	
 	  This class uses an instance of SigmaDamgardJurikEncryptedZeroVerifier with:
-	  	•	Common input: (n,c’) where c’=c*(1+n)^(-x) mod N'
+	  		Common input: (n,c') where c' =c*(1+n)^(-x) mod N'
 	
 	*/	
 	
@@ -142,7 +142,7 @@ public class SigmaDJEncryptedValueVerifierComputation implements SigmaVerifierCo
 	 */
 	public boolean verify(SigmaCommonInput in, SigmaProtocolMsg a, SigmaProtocolMsg z) {
 		/*
-		 * Converts the input (n, c, x) to (n, c') where c’ = c*(1+n)^(-x) mod N'.
+		 * Converts the input (n, c, x) to (n, c') where c' = c*(1+n)^(-x) mod N'.
 		 */
 		if (!(in instanceof SigmaDJEncryptedValueCommonInput)){
 			throw new IllegalArgumentException("the given input must be an instance of SigmaDJEncryptedValueCommonInput");

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroProverComputation.java
@@ -52,9 +52,9 @@ public class SigmaDJEncryptedZeroProverComputation implements SigmaProverComputa
 
 	/*	
 	  This class computes the following calculations:
-		  	SAMPLE random value s <- Z*n 
-			COMPUTE a = s^N mod N’
-			COMPUTE z = s*r^e mod n.
+        SAMPLE random value s <- Z*n 
+        COMPUTE a = s^N mod N'
+        COMPUTE z = s*r^e mod n.
 	
 	*/	
 	
@@ -127,7 +127,7 @@ public class SigmaDJEncryptedZeroProverComputation implements SigmaProverComputa
 	/**
 	 * Computes the first message of the protocol.<p>
 	 * "SAMPLE random value s <- Z*n<p>
-	 * COMPUTE a = s^N mod N’". 
+	 * COMPUTE a = s^N mod N'". 
 	 * @param input MUST be an instance of SigmaDJEncryptedZeroProverInput.
 	 * @return the computed message
 	 * @throws IllegalArgumentException if input is not an instance of SigmaDJEncryptedZeroProverInput.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroSimulator.java
@@ -50,7 +50,7 @@ public class SigmaDJEncryptedZeroSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random value z <- Z*n
-			COMPUTE a = z^N/c^e mod N’ 
+			COMPUTE a = z^N/c^e mod N'
 			OUTPUT (a,e,z)
 	*/
 	
@@ -133,7 +133,7 @@ public class SigmaDJEncryptedZeroSimulator implements SigmaSimulator{
 		BigInteger NTag = n.pow(lengthParameter + 1);
 		BigInteger e = new BigInteger(1, challenge);
 		
-		//Compute a = z^N/c^e mod N’
+		//Compute a = z^N/c^e mod N'
 		BigInteger zToN = z.modPow(N, NTag);
 		BigInteger denominator = djInput.getCiphertext().getCipher().modPow(e, NTag);
 		BigInteger denomInv = denominator.modInverse(NTag);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikEncryptedZero/SigmaDJEncryptedZeroVerifierComputation.java
@@ -49,7 +49,7 @@ public class SigmaDJEncryptedZeroVerifierComputation implements SigmaVerifierCom
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random challenge  e -< {0, 1}^t 
-			ACC IFF c,a,z are relatively prime to n AND z^N = (a*c^e) mod N’
+			ACC IFF c,a,z are relatively prime to n AND z^N = (a*c^e) mod N'
         
 	*/
 	
@@ -138,7 +138,7 @@ public class SigmaDJEncryptedZeroVerifierComputation implements SigmaVerifierCom
 
 	/**
 	 * Computes the verification of the protocol.<p>
-	 * 	"ACC IFF c,a,z are relatively prime to n AND z^N = (a*c^e) mod N’".
+	 * 	"ACC IFF c,a,z are relatively prime to n AND z^N = (a*c^e) mod N'".
 	 * @param input MUST be an instance of SigmaDJEncryptedZeroCommonInput.
 	 * @param z second message from prover
 	 * @return true if the proof has been verified; false, otherwise.
@@ -190,7 +190,7 @@ public class SigmaDJEncryptedZeroVerifierComputation implements SigmaVerifierCom
 		//Calculate z^N mod N' (left side of the equation).
 		BigInteger left = zBI.modPow(N, NTag);
 		
-		//Calculate (a*c^e) mod N’ (left side of the equation).
+		//Calculate (a*c^e) mod N' (left side of the equation).
 		//Convert e to BigInteger.
 		BigInteger eBI = new BigInteger(1, e);
 		BigInteger cToe = c.modPow(eBI, NTag);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductProverComputation.java
@@ -51,7 +51,7 @@ public class SigmaDJProductProverComputation implements SigmaProverComputation, 
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE random values d <- ZN, rd <- Z*n, rdb <- Z*n 
-		  	COMPUTE a1=(1+n)^drd^N mod N’ and a2=(1+n)^(d*x2)rdb^N mod N’ and SET a = (a1,a2)
+		  	COMPUTE a1=(1+n)^drd^N mod N' and a2=(1+n)^(d*x2)rdb^N mod N' and SET a = (a1,a2)
 			COMPUTE z1=e*x1+d mod N, z2 = r1^e*rd mod n, z3=(r2^z1)/(rdb*r3^e) mod n, and SET z=(z1,z2,z3)
 	*/	
 	
@@ -162,7 +162,7 @@ public class SigmaDJProductProverComputation implements SigmaProverComputation, 
 	/**
 	 * Computes the first message of the protocol.<p>
 	 * "SAMPLE random values d <- ZN, rd <- Z*n, rdb <- Z*n<p>
-	 *  COMPUTE a1 = (1+n)^d*rd^N mod N’ and a2 = ((1+n)^(d*x2))*(rdb^N) mod N’ and SET a = (a1,a2)". 
+	 *  COMPUTE a1 = (1+n)^d*rd^N mod N' and a2 = ((1+n)^(d*x2))*(rdb^N) mod N' and SET a = (a1,a2)". 
 	 * @param input MUST be an instance of SigmaDJProductProverInput.
 	 * @return the computed message
 	 * @throws IllegalArgumentException if input is not an instance of SigmaDJProductProverInput.
@@ -178,7 +178,7 @@ public class SigmaDJProductProverComputation implements SigmaProverComputation, 
 		BigInteger nPlusOneToD = nPlusOne.modPow(d, NTag);
 		//Calculate rd^N
 		BigInteger rdToN = rd.modPow(N, NTag);
-		//Calculate a1=(1+n)^d*rd^N mod N’
+		//Calculate a1=(1+n)^d*rd^N mod N'
 		BigInteger a1 = nPlusOneToD.multiply(rdToN).mod(NTag);
 		
 		//Calculate (1+n)^(d*x2)
@@ -186,7 +186,7 @@ public class SigmaDJProductProverComputation implements SigmaProverComputation, 
 		BigInteger nPlusOnePow = nPlusOne.modPow(exponent, NTag);
 		//Calculate rdb^N
 		BigInteger rdbToN = rdb.modPow(N, NTag);
-		//Calculate a2 = ((1+n)^(d*x2))*(rdb^N) mod N’
+		//Calculate a2 = ((1+n)^(d*x2))*(rdb^N) mod N'
 		BigInteger a2 = nPlusOnePow.multiply(rdbToN).mod(NTag);
 		
 		//Create and return SigmaDJProductFirstMsg with a1 and a2.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductSimulator.java
@@ -50,7 +50,7 @@ public class SigmaDJProductSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE random values z1 <- ZN, z2 <- Z*n, z3 <- Z*n
-			COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N’ AND a2 = c2^z1/(z3^N*c3^e) mod N’
+			COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N' AND a2 = c2^z1/(z3^N*c3^e) mod N'
 			OUTPUT (a,e,z) where a = (a1,a2) AND z=(z1,z2,z3)
 
 	*/
@@ -113,7 +113,7 @@ public class SigmaDJProductSimulator implements SigmaSimulator{
 	public SigmaSimulatorOutput simulate(SigmaCommonInput input, byte[] challenge) throws CheatAttemptException{
 		/*
 		 * SAMPLE random values z1 <- ZN, z2 <- Z*n, z3 <- Z*n
-		 * COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N’ AND a2 = c2^z1/(z3^N*c3^e) mod N’
+		 * COMPUTE a1 = (1+n)^z1*(z2^N/c1^e) mod N' AND a2 = c2^z1/(z3^N*c3^e) mod N'
 		 * OUTPUT (a,e,z) where a = (a1,a2) AND z=(z1,z2,z3)
 		 */
 		
@@ -147,7 +147,7 @@ public class SigmaDJProductSimulator implements SigmaSimulator{
 		//Create the BigInteger value out of the challenge.
 		BigInteger e = new BigInteger(1, challenge);
 		
-		//Compute a1 = (1+n)^z1*(z2^N/c1^e) mod N’
+		//Compute a1 = (1+n)^z1*(z2^N/c1^e) mod N'
 		BigInteger nPlusOne = n.add(BigInteger.ONE);
 		BigInteger leftMul = nPlusOne.modPow(z1, NTag);
 		BigInteger z2ToN = z2.modPow(N, NTag);
@@ -156,7 +156,7 @@ public class SigmaDJProductSimulator implements SigmaSimulator{
 		BigInteger rightMul = z2ToN.multiply(denomInv).mod(NTag);
 		BigInteger a1 = leftMul.multiply(rightMul).mod(NTag);
 		
-		//Compute a2 = c2^z1/(z3^N*c3^e) mod N’
+		//Compute a2 = c2^z1/(z3^N*c3^e) mod N'
 		BigInteger c2ToZ1 = djInput.getC2().getCipher().modPow(z1, NTag);
 		BigInteger z3ToN = z3.modPow(N, NTag);
 		BigInteger c3ToE = djInput.getC3().getCipher().modPow(e, NTag);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/damgardJurikProduct/SigmaDJProductVerifierComputation.java
@@ -49,8 +49,8 @@ public class SigmaDJProductVerifierComputation implements SigmaVerifierComputati
 	  This class computes the following calculations:
 		  	SAMPLE a random challenge  e -< {0, 1}^t 
 			ACC IFF c1,c2,c3,a1,a2,z1,z2,z3 are relatively prime to n 
-				AND c1^e*a1 = (1+n)^z1*z2^N mod N’ 
-				AND (c2^z1)/(a2*c3^e) = z3^N mod N’
+				AND c1^e*a1 = (1+n)^z1*z2^N mod N'
+				AND (c2^z1)/(a2*c3^e) = z3^N mod N'
         
 	*/
 	
@@ -164,8 +164,8 @@ public class SigmaDJProductVerifierComputation implements SigmaVerifierComputati
 	/**
 	 * Computes the verification of the protocol.<p>
 	 * 	"ACC IFF c1,c2,c3,a1,a2,z1,z2,z3 are relatively prime to n <p>
-				AND c1^e*a1 = (1+n)^z1*z2^N mod N’ <p>
-				AND (c2^z1)/(a2*c3^e) = z3^N mod N’".
+				AND c1^e*a1 = (1+n)^z1*z2^N mod N'<p>
+				AND (c2^z1)/(a2*c3^e) = z3^N mod N'".
 	 * @param z second message from prover
 	 * @return true if the proof has been verified; false, otherwise.
 	 * @throws IllegalArgumentException if the first prover message is not an instance of SigmaDJProductFirstMsg
@@ -211,7 +211,7 @@ public class SigmaDJProductVerifierComputation implements SigmaVerifierComputati
 		//Convert e to BigInteger.
 		BigInteger eBI = new BigInteger(1, e);
 		
-		//Check that c1^e*a1 = (1+n)^z1*z2^N mod N’ 
+		//Check that c1^e*a1 = (1+n)^z1*z2^N mod N'
 		BigInteger c1ToE = c1.modPow(eBI, NTag);
 		BigInteger left = c1ToE.multiply(a1).mod(NTag);
 		BigInteger nPlusOneToZ1 = n.add(BigInteger.ONE).modPow(z1, NTag);
@@ -221,7 +221,7 @@ public class SigmaDJProductVerifierComputation implements SigmaVerifierComputati
 		//If left and right sides of the equation are not equal, set verified to false.
 		verified = verified && left.equals(right);
 		
-		//Check that (c2^z1)/(a2*c3^e) = z3^N mod N’
+		//Check that (c2^z1)/(a2*c3^e) = z3^N mod N'
 		BigInteger numerator = c2.modPow(z1, NTag);
 		BigInteger c3ToE = c3.modPow(eBI, NTag);
 		BigInteger denominator = a2.multiply(c3ToE).mod(NTag);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dh/SigmaDHSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dh/SigmaDHSimulator.java
@@ -50,9 +50,9 @@ import edu.biu.scapi.primitives.dlog.GroupElement;
 public class SigmaDHSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
-		  	SAMPLE a random z <- Zq
-			COMPUTE a = g^z*u^(-e) and b = h^0z*v^(-e) (where –e here means –e mod q)
-			OUTPUT ((a,b),e,z)
+        SAMPLE a random z <- Zq
+        COMPUTE a = g^z*u^(-e) and b = h^0z*v^(-e) (where -e here means -e mod q)
+        OUTPUT ((a,b),e,z)
 	
 	*/
 
@@ -124,14 +124,14 @@ public class SigmaDHSimulator implements SigmaSimulator{
 		//Sample a random z <- Zq
 		BigInteger z = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, random);
 		
-		//Compute a = g^z*u^(-e) (where –e here means –e mod q)
+		//Compute a = g^z*u^(-e) (where -e here means -e mod q)
 		GroupElement gToZ = dlog.exponentiate(dlog.getGenerator(), z);
 		BigInteger e = new BigInteger(1, challenge);
 		BigInteger minusE = dlog.getOrder().subtract(e);
 		GroupElement uToE = dlog.exponentiate(dhInput.getU(), minusE);
 		GroupElement a = dlog.multiplyGroupElements(gToZ, uToE);
 		
-		//Compute b = h^z*v^(-e) (where –e here means –e mod q)
+		//Compute b = h^z*v^(-e) (where -e here means -e mod q)
 		GroupElement hToZ = dlog.exponentiate(dhInput.getH(), z);
 		GroupElement vToE = dlog.exponentiate(dhInput.getV(), minusE);
 		GroupElement b = dlog.multiplyGroupElements(hToZ, vToE);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedCommonInput.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedCommonInput.java
@@ -33,7 +33,7 @@ import edu.biu.scapi.primitives.dlog.GroupElement;
 
 /**
  * Concrete implementation of SigmaProtocol input, used by the SigmaDHExtended verifier and simulator.<p>
- * In SigmaProtocolDHExtended, the common input contains an extended DH tuple - (g1,…,gm,h1,…,hm).
+ * In SigmaProtocolDHExtended, the common input contains an extended DH tuple - (g1,...,gm,h1,...,hm).
  * 
  * @author Cryptography and Computer Security Research Group Department of Computer Science Bar-Ilan University (Moriya Farbstein)
  *

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedProverComputation.java
@@ -44,7 +44,7 @@ import edu.biu.scapi.primitives.dlog.GroupElementSendableData;
 /**
  * Concrete implementation of Sigma Protocol prover computation. <p>
  * 
- * This protocol is used for a prover to convince a verifier that the input tuple (g1,…,gm,h1,…,hm) is an 
+ * This protocol is used for a prover to convince a verifier that the input tuple (g1,...,gm,h1,...,hm) is an 
  * extended Diffie-Hellman tuple, meaning that there exists a single w in Zq such that hi=gi^w for all i.<p>
  * 
  * The pseudo code of this protocol can be found in Protocol 1.3 of pseudo codes document at {@link http://crypto.biu.ac.il/scapi/SDK_Pseudocode_SCAPI_V2.0.0.pdf}.<p>
@@ -56,7 +56,7 @@ public class SigmaDHExtendedProverComputation implements SigmaProverComputation,
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random r <- Zq and COMPUTE ai = gi^r for all i
-			SET a=(a1,…,am)
+			SET a=(a1,...,am)
 			COMPUTE z = r + ew mod q.
 	*/	
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedProverInput.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedProverInput.java
@@ -32,7 +32,7 @@ import edu.biu.scapi.primitives.dlog.GroupElement;
 
 /**
  * Concrete implementation of SigmaProtocol input, used by the SigmaDHExtendedProver.<p>
- * In SigmaProtocolDHExtended, the prover gets an extended DH tuple - (g1,…,gm,h1,…,hm) and a value w in Zq such that hi=gi^w for all i.
+ * In SigmaProtocolDHExtended, the prover gets an extended DH tuple - (g1,...,gm,h1,...,hm) and a value w in Zq such that hi=gi^w for all i.
  * 
  * @author Cryptography and Computer Security Research Group Department of Computer Science Bar-Ilan University (Moriya Farbstein)
  *
@@ -44,7 +44,7 @@ public class SigmaDHExtendedProverInput implements SigmaProverInput{
 	
 	/**
 	 * Sets the input for the prover. <p>
-	 * The prover gets an extended DH tuple - (g1,…,gm,h1,…,hm) and a value w in Zq such that hi=gi^w for all i.
+	 * The prover gets an extended DH tuple - (g1,...,gm,h1,...,hm) and a value w in Zq such that hi=gi^w for all i.
 	 * @param gArray
 	 * @param hArray
 	 * @param w

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedSimulator.java
@@ -41,7 +41,7 @@ import edu.biu.scapi.primitives.dlog.GroupElementSendableData;
 
 /**
  * Concrete implementation of Sigma Simulator.<p>
- * This implementation simulates the case that the prover convince a verifier that the input tuple (g1,…,gm,h1,…,hm) is an 
+ * This implementation simulates the case that the prover convince a verifier that the input tuple (g1,...,gm,h1,...,hm) is an 
  * extended Diffie-Hellman tuple, meaning that there exists a single w in Zq such that hi=gi^w for all i.<P>
  * 
  * The pseudo code of this protocol can be found in Protocol 1.3 of pseudo codes document at {@link http://crypto.biu.ac.il/scapi/SDK_Pseudocode_SCAPI_V2.0.0.pdf}.<p>
@@ -53,8 +53,8 @@ public class SigmaDHExtendedSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random z <- Zq
-			For every i=1,…,m, COMPUTE ai = gi^z*hi^(-e) (where –e here means –e mod q)
-			OUTPUT ((a1,…,am),e,z)
+			For every i=1,...,m, COMPUTE ai = gi^z*hi^(-e) (where -e here means -e mod q)
+			OUTPUT ((a1,...,am),e,z)
 	*/
 
 	private DlogGroup dlog; 		//Underlying DlogGroup.
@@ -133,14 +133,14 @@ public class SigmaDHExtendedSimulator implements SigmaSimulator{
 		
 		// The simulation is: 
 		//	SAMPLE a random z <- Zq
-		//	For every i=1,…,m, COMPUTE ai = gi^z*hi^(-e) (where –e here means –e mod q)
-		//	OUTPUT ((a1,…,am),e,z)
+		//	For every i=1,...,m, COMPUTE ai = gi^z*hi^(-e) (where -e here means -e mod q)
+		//	OUTPUT ((a1,...,am),e,z)
 		
 		//Sample a random z <- Zq
 		BigInteger qMinusOne = dlog.getOrder().subtract(BigInteger.ONE);
 		BigInteger z = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, random);
 		
-		//Compute -e (where –e here means –e mod q)
+		//Compute -e (where -e here means -e mod q)
 		BigInteger e = new BigInteger(1, challenge);
 		BigInteger minusE = dlog.getOrder().subtract(e);
 		
@@ -148,7 +148,7 @@ public class SigmaDHExtendedSimulator implements SigmaSimulator{
 		GroupElement gToZ;
 		GroupElement hToE;
 		GroupElement a;
-		//For every i=1,…,m, Compute ai = gi^z*hi^(-e) 
+		//For every i=1,...,m, Compute ai = gi^z*hi^(-e) 
 		for (int i=0; i<size; i++){
 			
 			gToZ = dlog.exponentiate(gArray.get(i), z);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dhExtended/SigmaDHExtendedVerifierComputation.java
@@ -41,7 +41,7 @@ import edu.biu.scapi.primitives.dlog.GroupElementSendableData;
 /**
  * Concrete implementation of Sigma Protocol verifier computation. <p>
  * 
- * This protocol is used for a prover to convince a verifier that the input tuple (g1,…,gm,h1,…,hm) is an 
+ * This protocol is used for a prover to convince a verifier that the input tuple (g1,...,gm,h1,...,hm) is an 
  * extended Diffie-Hellman tuple, meaning that there exists a single w in Zq such that hi=gi^w for all i.<p>
  * 
  * The pseudo code of this protocol can be found in Protocol 1.3 of pseudo codes document at {@link http://crypto.biu.ac.il/scapi/SDK_Pseudocode_SCAPI_V2.0.0.pdf}.<p>
@@ -54,7 +54,7 @@ public class SigmaDHExtendedVerifierComputation implements SigmaVerifierComputat
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random challenge  e <- {0, 1}^t 
-			ACC IFF VALID_PARAMS(G,q,g)=TRUE AND all g1,…,gm in G AND for all i=1,…,m it holds that gi^z = ai*hi^e        
+			ACC IFF VALID_PARAMS(G,q,g)=TRUE AND all g1,...,gm in G AND for all i=1,...,m it holds that gi^z = ai*hi^e        
               
 	*/	
 	
@@ -140,7 +140,7 @@ public class SigmaDHExtendedVerifierComputation implements SigmaVerifierComputat
 	/**
 	 * Computes the protocol's verification.<p>
 	 * Computes the following line from the protocol:<p>
-	 * 	"ACC IFF VALID_PARAMS(G,q,g)=TRUE AND all g1,…,gm in G AND for all i=1,…,m it holds that gi^z = ai*hi^e".   <p>  
+	 * 	"ACC IFF VALID_PARAMS(G,q,g)=TRUE AND all g1,...,gm in G AND for all i=1,...,m it holds that gi^z = ai*hi^e".   <p>  
 	 * @param input MUST be an instance of SigmaDHExtendedCommonInput.
 	 * @param z second message from prover
 	 * @return true if the proof has been verified; false, otherwise.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dlog/SigmaDlogSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/dlog/SigmaDlogSimulator.java
@@ -52,7 +52,7 @@ public class SigmaDlogSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
 		  	SAMPLE a random z <- Zq
-			COMPUTE a = g^z*h^(-e)  (where –e here means –e mod q)
+			COMPUTE a = g^z*h^(-e)  (where -e here means -e mod q)
 			OUTPUT (a,e,z).	
 	*/
 
@@ -107,7 +107,7 @@ public class SigmaDlogSimulator implements SigmaSimulator{
 	/**
 	 * Computes the simulator computation, using the given challenge.<p>
 	 * "SAMPLE a random z <- Zq <p>
-	 *	COMPUTE a = g^z*h^(-e)  (where –e here means –e mod q)<p>
+	 *	COMPUTE a = g^z*h^(-e)  (where -e here means -e mod q)<p>
 	 *	OUTPUT (a,e,z)".	<p>
 	 * @param input MUST be an instance of SigmaDlogCommonInput.
 	 * @param challenge
@@ -130,7 +130,7 @@ public class SigmaDlogSimulator implements SigmaSimulator{
 		//SAMPLE a random z <- Zq
 		BigInteger z = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, random);
 		
-		//COMPUTE a = g^z*h^(-e)  (where –e here means –e mod q)
+		//COMPUTE a = g^z*h^(-e)  (where -e here means -e mod q)
 		GroupElement gToZ = dlog.exponentiate(dlog.getGenerator(), z);
 		BigInteger e = new BigInteger(1, challenge);
 		BigInteger minusE = dlog.getOrder().subtract(e);
@@ -145,7 +145,7 @@ public class SigmaDlogSimulator implements SigmaSimulator{
 	/**
 	 * Computes the simulator computation, using random challenge.<p>
 	 * "SAMPLE a random z <- Zq<p>
-	 *	COMPUTE a = g^z*h^(-e)  (where –e here means –e mod q)<p>
+	 *	COMPUTE a = g^z*h^(-e)  (where -e here means -e mod q)<p>
 	 *	OUTPUT (a,e,z)".	<p>
 	 * @param input MUST be an instance of SigmaDlogCommonInput.
 	 * @return the output of the computation - (a, e, z).

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeProverComputation.java
@@ -51,9 +51,9 @@ public class SigmaElGamalCmtKnowledgeProverComputation implements SigmaProverCom
 
 	/*	
 	  This class uses an instance of SigmaDlogProver with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h (1st element of commitment)
-		•	P’s private input: a value w in Zq such that h = g^w (given w can decrypt and so this proves knowledge of committed value).	
+        Common parameters (G,q,g) and t
+        Common input: h (1st element of commitment)
+        P's private input: a value w in Zq such that h = g^w (given w can decrypt and so this proves knowledge of committed value).	
 	*/	 
 	
 	private SigmaDlogProverComputation sigmaDlog;	//underlying SigmaDlogProver to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeSimulator.java
@@ -48,8 +48,8 @@ public class SigmaElGamalCmtKnowledgeSimulator implements SigmaSimulator{
 
 	/*	
 	  This class uses an instance of SigmaDlogSimulator with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h (1st element of commitment)
+        Common parameters (G,q,g) and t
+        Common input: h (1st element of commitment)
 	*/
 
 	private SigmaDlogSimulator dlogSim; //underlying SigmaDlogSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCmtKnowledge/SigmaElGamalCmtKnowledgeVerifierComputation.java
@@ -50,9 +50,9 @@ public class SigmaElGamalCmtKnowledgeVerifierComputation implements SigmaVerifie
 
 	/*	
 	  This class uses an instance of SigmaDlogVerifier with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h (1st element of commitment)
-	*/	
+        Common parameters (G,q,g) and t
+        Common input: h (1st element of commitment)
+	*/
 	
 	private SigmaDlogVerifierComputation sigmaDlog;//underlying SigmaDlogVerifier to use.
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueProverComputation.java
@@ -52,9 +52,9 @@ public class SigmaElGamalCommittedValueProverComputation implements SigmaProverC
 
 	/*	
 	  This class uses an instance of SigmaDHProver with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
-		•	P’s private input: a value r in Zq such that c1=g^r and c2/x =h^r
+        Common parameters (G,q,g) and t
+        Common input: (g,h,u,v) = (g,h,c1,c2/x)
+        P's private input: a value r in Zq such that c1=g^r and c2/x =h^r
 
 	*/	 
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueSimulator.java
@@ -49,8 +49,8 @@ public class SigmaElGamalCommittedValueSimulator implements SigmaSimulator{
 
 	/*	
 	  This class uses an instance of SigmaDHSimulator with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
+        Common parameters (G,q,g) and t
+        Common input: (g,h,u,v) = (g,h,c1,c2/x)
 	*/
 
 	private SigmaDHSimulator dhSim; 	//underlying SigmaDHSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalCommittedValue/SigmaElGamalCommittedValueVerifierComputation.java
@@ -51,8 +51,8 @@ public class SigmaElGamalCommittedValueVerifierComputation implements SigmaVerif
 
 	/*	
 	  This class uses an instance of SigmaDHVerifier with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
+        Common parameters (G,q,g) and t
+        Common input: (g,h,u,v) = (g,h,c1,c2/x)
 	*/	
 	
 	private SigmaDHVerifierComputation sigmaDH;	//underlying SigmaDHVerifier to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueProverComputation.java
@@ -56,13 +56,13 @@ public class SigmaElGamalEncryptedValueProverComputation implements SigmaProverC
 	  
 	  This class uses an instance of SigmaDHProver with:
 	  
-	  		•	Common DlogGroup
-	  	In case we use knowledge of the private key:
-			•	Common input: (g,h,u,v) = (g,c1,h,c2/x) and
-			•	P’s private input: a value w <- Zq such that h=g^w and c2/x =c1^w
-		In case we use knowledge of the randomness used to encrypt:
-			•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
-			•	P’s private input: a value r <- Zq such that c1=g^r and c2/x =h^r.
+        Common DlogGroup
+        In case we use knowledge of the private key:
+          Common input: (g,h,u,v) = (g,c1,h,c2/x) and
+          P's private input: a value w <- Zq such that h=g^w and c2/x =c1^w
+        In case we use knowledge of the randomness used to encrypt:
+          Common input: (g,h,u,v) = (g,h,c1,c2/x)
+          P's private input: a value r <- Zq such that c1=g^r and c2/x =h^r.
 	*/	 
 	
 	private SigmaDHProverComputation sigmaDH;	//underlying SigmaDHProver to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueSimulator.java
@@ -52,11 +52,11 @@ public class SigmaElGamalEncryptedValueSimulator implements SigmaSimulator{
 	  the secret key or it knows the randomness used to generate the ciphertext.
 	  
 	  This class uses an instance of SigmaDHSimulator with:
-	  	•	Common DlogGroup
-	  	In case we use knowledge of the private key:
-			•	Common input: (g,h,u,v) = (g,c1,h,c2/x) and
-		In case we use knowledge of the randomness used to encrypt:
-			•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
+        Common DlogGroup
+        In case we use knowledge of the private key:
+          Common input: (g,h,u,v) = (g,c1,h,c2/x) and
+        In case we use knowledge of the randomness used to encrypt:
+          Common input: (g,h,u,v) = (g,h,c1,c2/x)
 	*/
 	
 	private SigmaDHSimulator dhSim; //underlying SigmaDHSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalEncryptedValue/SigmaElGamalEncryptedValueVerifierComputation.java
@@ -54,13 +54,13 @@ public class SigmaElGamalEncryptedValueVerifierComputation implements SigmaVerif
 	  
 	  This class uses an instance of SigmaDHProver with:
 	  
-	  		•	Common DlogGroup
-	  	In case we use knowledge of the private key:
-			•	Common input: (g,h,u,v) = (g,c1,h,c2/x) and
-			•	P’s private input: a value w <- Zq such that h=g^w and c2/x =c1^w
-		In case we use knowledge of the randomness used to encrypt:
-			•	Common input: (g,h,u,v) = (g,h,c1,c2/x)
-			•	P’s private input: a value r <- Zq such that c1=g^r and c2/x =h^r.
+        Common DlogGroup
+        In case we use knowledge of the private key:
+          Common input: (g,h,u,v) = (g,c1,h,c2/x) and
+          P's private input: a value w <- Zq such that h=g^w and c2/x =c1^w
+        In case we use knowledge of the randomness used to encrypt:
+          Common input: (g,h,u,v) = (g,h,c1,c2/x)
+          P's private input: a value r <- Zq such that c1=g^r and c2/x =h^r.
 	*/	
 	
 	private SigmaDHVerifierComputation sigmaDH;	//underlying SigmaDHVerifier to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeyProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeyProverComputation.java
@@ -50,8 +50,8 @@ public class SigmaElGamalPrivateKeyProverComputation implements SigmaProverCompu
 	
 	/*	
 	  This class uses an instance of SigmaDlogProver with:
-	  	•	Common DlogGroup
-		•	input: h (the public key) and a value w<- Zq such that h=g^w (the private key).
+        Common DlogGroup
+        input: h (the public key) and a value w<- Zq such that h=g^w (the private key).
 	
 	*/	 
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeySimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeySimulator.java
@@ -47,8 +47,8 @@ public class SigmaElGamalPrivateKeySimulator implements SigmaSimulator{
 
 	/*	
 	  This class uses an instance of SigmaDlogSimulator with:
-	  	•	Common DlogGroup
-		•	input: h (the public key).
+        Common DlogGroup
+        input: h (the public key).
 	*/
 
 	private SigmaDlogSimulator dlogSim; //underlying SigmaDlogSimulator to use.

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeyVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/elGamalPrivateKey/SigmaElGamalPrivateKeyVerifierComputation.java
@@ -49,8 +49,8 @@ public class SigmaElGamalPrivateKeyVerifierComputation implements SigmaVerifierC
 
 	/*	
 	  This class uses an instance of SigmaDlogVerifier with:
-	  	•	Common DlogGroup
-		•	Common input: h (the public key).
+        Common DlogGroup
+        Common input: h (the public key).
 	
 	*/	
 	

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleProverComputation.java
@@ -58,12 +58,12 @@ public class SigmaORMultipleProverComputation implements SigmaProverComputation{
 			For every j not in I, SAMPLE a random element ej <- GF[2^t]
 			For every j not in I, RUN the simulator on statement xj and challenge ej to get transcript (aj,ej,zj)
 			For every i in I, RUN the prover P on statement xi to get first message ai
-			SET a=(a1,…,an)
+			SET a=(a1,...,an)
 			
 			INTERPOLATE the points (0,e) and {(j,ej)} for every j not in I to obtain a degree n-k polynomial Q (s.t. Q(0)=e and Q(j)=ej for every j not in I)
 			For every i in I, SET ei = Q(i)
 			For every i in I, COMPUTE the response zi to (ai, ei) in SigmaI using input (xi,wi)
-			The message is Q,e1,z1,…,en,zn (where by Q we mean its coefficients)
+			The message is Q,e1,z1,...,en,zn (where by Q we mean its coefficients)
 	*/
 	
 	private Hashtable<Integer, SigmaProverComputation> provers;	// Underlying Sigma protocol's provers to the OR calculation.
@@ -199,9 +199,9 @@ public class SigmaORMultipleProverComputation implements SigmaProverComputation{
 	 * "For every j not in I, SAMPLE a random element ej <- GF[2^t]<p>
 	 *  For every j not in I, RUN the simulator on statement xj and challenge ej to get transcript (aj,ej,zj)<p>
 		For every i in I, RUN the prover P on statement xi to get first message ai<p>
-		SET a=(a1,…,an)". 
+		SET a=(a1,...,an)". 
 	 * @param input MUST be an instance of SigmaORMultipleInput.
-	 * @return SigmaMultipleMsg contains a1, …, am. 
+	 * @return SigmaMultipleMsg contains a1, ..., am. 
 	 * @throws IllegalArgumentException if input is not an instance of SigmaORMultipleInput.
 	 * @throws IllegalArgumentException if the number of given inputs is different from the number of underlying provers. 
 	 */
@@ -260,9 +260,9 @@ public class SigmaORMultipleProverComputation implements SigmaProverComputation{
 	 * "INTERPOLATE the points (0,e) and {(j,ej)} for every j not in I to obtain a degree n-k polynomial Q (s.t. Q(0)=e and Q(j)=ej for every j not in I)<p>
 			For every i in I, SET ei = Q(i)<p>
 			For every i in I, COMPUTE the response zi to (ai, ei) in Sigmai using input (xi,wi)<p>
-			The message is Q,e1,z1,…,en,zn (where by Q we mean its coefficients)".<p>
+			The message is Q,e1,z1,...,en,zn (where by Q we mean its coefficients)".<p>
 	 * @param challenge
-	 * @return SigmaMultipleMsg contains z1, …, zm.
+	 * @return SigmaMultipleMsg contains z1, ..., zm.
 	 * @throws CheatAttemptException if the received challenge's length is not equal to the soundness parameter.
 	 */
 	public SigmaProtocolMsg computeSecondMsg(byte[] challenge) throws CheatAttemptException {

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleSimulator.java
@@ -49,10 +49,10 @@ public class SigmaORMultipleSimulator implements SigmaSimulator{
 
 	/*	
 	  This class computes the following calculations:
-		  	SAMPLE random points e1,…,en-k in GF[2t].
-			COMPUTE the polynomial Q and values en-k+1,…,en like in the protocol.
-			RUN the simulator on each statement/challenge pair (xi,ei) for all i=1,…,n to obtain (ai,ei,zi).
-			OUTPUT (a1,e1,z1),…, (an,en,zn).
+		  	SAMPLE random points e1,...,en-k in GF[2t].
+			COMPUTE the polynomial Q and values en-k+1,...,en like in the protocol.
+			RUN the simulator on each statement/challenge pair (xi,ei) for all i=1,...,n to obtain (ai,ei,zi).
+			OUTPUT (a1,e1,z1),..., (an,en,zn).
 	*/
 	
 	private ArrayList<SigmaSimulator> simulators;	// Underlying simulators.
@@ -163,7 +163,7 @@ public class SigmaORMultipleSimulator implements SigmaSimulator{
 		ArrayList<byte[]> eOutputs = new ArrayList<byte[]>();
 		ArrayList<SigmaProtocolMsg> zOutputs = new ArrayList<SigmaProtocolMsg>();
 		SigmaSimulatorOutput output;
-		//Run the simulator on each statement,challenge pair (xi,ei) for all i=1,…,n to obtain (ai,ei,zi).
+		//Run the simulator on each statement,challenge pair (xi,ei) for all i=1,...,n to obtain (ai,ei,zi).
 		for (int i = 0; i < len; i++){
 			try {
 				output = simulators.get(i).simulate(orInput.getInputs().get(i), challenges[i]);

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/orMultiple/SigmaORMultipleVerifierComputation.java
@@ -49,10 +49,10 @@ public class SigmaORMultipleVerifierComputation implements SigmaVerifierComputat
 	/*	
 	  Let (ai,ei,zi) denote the steps of a Sigma protocol Sigmai for proving that xi is in LRi 
 	  This class computes the following calculations:
-		WAIT for messages a1,…,an
+		WAIT for messages a1,...,an
 		SAMPLE a single random challenge  e <- GF[2^t]
 		
-		ACC IFF Q is of degree n-k AND Q(i)=ei for all i=1,…,n AND Q(0)=e, and the verifier output on (ai,ei,zi) for all i=1,…,n is ACC
+		ACC IFF Q is of degree n-k AND Q(i)=ei for all i=1,...,n AND Q(0)=e, and the verifier output on (ai,ei,zi) for all i=1,...,n is ACC
        
 	*/
 	
@@ -70,7 +70,7 @@ public class SigmaORMultipleVerifierComputation implements SigmaVerifierComputat
 	//Samples the challenge as a field element.
 	private native byte[] sampleChallenge(long[] pointer);
 	
-	//Checks if Q is of degree n-k AND Q(i)=ei for all i=1,…,n AND Q(0)=e. This function also deletes the allocated memory.
+	//Checks if Q is of degree n-k AND Q(i)=ei for all i=1,...,n AND Q(0)=e. This function also deletes the allocated memory.
 	private native boolean checkPolynomialValidity(byte[][] polynomial, int k, long challengePointer, byte[][] challenges);
 	
 	//Sets the given challenge in the field.
@@ -195,7 +195,7 @@ public class SigmaORMultipleVerifierComputation implements SigmaVerifierComputat
 
 	/**
 	 * Computes the verification of the protocol.<p>
-	 * 	"ACC IFF Q is of degree n-k AND Q(i)=ei for all i=1,…,n AND Q(0)=e, and the verifier output on (ai,ei,zi) for all i=1,…,n is ACC".
+	 * 	"ACC IFF Q is of degree n-k AND Q(i)=ei for all i=1,...,n AND Q(0)=e, and the verifier output on (ai,ei,zi) for all i=1,...,n is ACC".
 	 * @param input MUST be an instance of SigmaORMultipleCommonInput.
 	 * @param a first message from prover
 	 * @param z second message from prover

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCmtKnowledge/SigmaPedersenCmtKnowledgeSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCmtKnowledge/SigmaPedersenCmtKnowledgeSimulator.java
@@ -48,9 +48,9 @@ import edu.biu.scapi.primitives.dlog.GroupElement;
 public class SigmaPedersenCmtKnowledgeSimulator implements SigmaSimulator{
 	/*	
 	  This class computes the following calculations:
-		  	SAMPLE random values u, v in Zq  
-			COMPUTE a = h^u*g^v*c^(-e) (where –e here means –e mod q)
-			OUTPUT (a,e,(u,v))
+        SAMPLE random values u, v in Zq  
+        COMPUTE a = h^u*g^v*c^(-e) (where -e here means -e mod q)
+        OUTPUT (a,e,(u,v))
 	*/
 
 	private DlogGroup dlog; 		//Underlying DlogGroup.
@@ -110,7 +110,7 @@ public class SigmaPedersenCmtKnowledgeSimulator implements SigmaSimulator{
 	 */
 	public SigmaSimulatorOutput simulate(SigmaCommonInput input, byte[] challenge) throws CheatAttemptException{
 		//  SAMPLE random values u, v in Zq  
-		//	COMPUTE a = h^u*g^v*c^(-e) (where –e here means –e mod q)
+		//	COMPUTE a = h^u*g^v*c^(-e) (where -e here means -e mod q)
 		//	OUTPUT (a,e,(u,v))
 		//
 		
@@ -129,7 +129,7 @@ public class SigmaPedersenCmtKnowledgeSimulator implements SigmaSimulator{
 		BigInteger u = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, random);
 		BigInteger v = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, random);
 		
-		//COMPUTE a = h^u*g^v*c^(-e) (where –e here means –e mod q)
+		//COMPUTE a = h^u*g^v*c^(-e) (where -e here means -e mod q)
 		//Compute h^u
 		GroupElement hToU = dlog.exponentiate(params.getH(), u);
 		//Compute g^v

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueProverComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueProverComputation.java
@@ -54,9 +54,9 @@ public class SigmaPedersenCommittedValueProverComputation implements SigmaProver
 	  Since c = g^r*h^x, it suffices to prove knowledge of r s.t. g^r = c*h^(-x). This is just a DLOG Sigma protocol.
 	  
 	  This class uses an instance of SigmaDlogProver with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h’ = c*h^(-x) 
-		•	P’s private input: a value r in Zq such that h’ = g^r
+      Common parameters (G,q,g) and t
+        Common input: h' = c*h^(-x) 
+        P's private input: a value r in Zq such that h' = g^r
 	*/	
 
 	private SigmaDlogProverComputation sigmaDlog;	//underlying SigmaDlogProver to use.
@@ -97,7 +97,7 @@ public class SigmaPedersenCommittedValueProverComputation implements SigmaProver
 		SigmaPedersenCommittedValueProverInput input = (SigmaPedersenCommittedValueProverInput) in;
 		SigmaPedersenCommittedValueCommonInput params = input.getCommonParams();
 		
-		//Convert the input to the underlying Dlog prover. h’ = c*h^(-x).
+		//Convert the input to the underlying Dlog prover. h' = c*h^(-x).
 		BigInteger minusX = dlog.getOrder().subtract(params.getX());
 		GroupElement hToX = dlog.exponentiate(params.getH(), minusX);
 		GroupElement c = params.getCommitment();

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueSimulator.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueSimulator.java
@@ -51,8 +51,8 @@ public class SigmaPedersenCommittedValueSimulator implements SigmaSimulator{
 	  Since c = g^r*h^x, it suffices to prove knowledge of r s.t. g^r = c*h^(-x). This is just a DLOG Sigma protocol.
 	  
 	  This class uses an instance of SigmaDlogSimulator with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h’ = c*h^(-x) 
+        Common parameters (G,q,g) and t
+        Common input: h' = c*h^(-x) 
 	*/
 
 	private SigmaDlogSimulator dlogSim; 	//underlying SigmaDlogSimulator to use.
@@ -142,7 +142,7 @@ public class SigmaPedersenCommittedValueSimulator implements SigmaSimulator{
 		}
 		SigmaPedersenCommittedValueCommonInput params = (SigmaPedersenCommittedValueCommonInput) in;
 		
-		//Convert the input to the underlying Dlog prover. h’ = c*h^(-x).
+		//Convert the input to the underlying Dlog prover. h' = c*h^(-x).
 		BigInteger minusX = dlog.getOrder().subtract(params.getX());
 		GroupElement hToX = dlog.exponentiate(params.getH(), minusX);
 		GroupElement c = params.getCommitment();

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueVerifierComputation.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/sigmaProtocol/pedersenCommittedValue/SigmaPedersenCommittedValueVerifierComputation.java
@@ -52,8 +52,8 @@ public class SigmaPedersenCommittedValueVerifierComputation implements SigmaVeri
 	  Since c = g^r*h^x, it suffices to prove knowledge of r s.t. g^r = c*h^(-x). This is just a DLOG Sigma protocol.
 	  
 	  This class uses an instance of SigmaDlogProver with:
-	  	•	Common parameters (G,q,g) and t
-		•	Common input: h’ = c*h^(-x) 
+        Common parameters (G,q,g) and t
+        Common input: h' = c*h^(-x) 
 	*/
 	
 	private SigmaDlogVerifierComputation sigmaDlog;	//underlying SigmaDlogVerifier to use.
@@ -94,7 +94,7 @@ public class SigmaPedersenCommittedValueVerifierComputation implements SigmaVeri
 		}
 		SigmaPedersenCommittedValueCommonInput input = (SigmaPedersenCommittedValueCommonInput) in;
 		
-		//Convert the input to the underlying Dlog prover. h’ = c*h^(-x).
+		//Convert the input to the underlying Dlog prover. h' = c*h^(-x).
 		BigInteger minusX = dlog.getOrder().subtract(input.getX());
 		GroupElement hToX = dlog.exponentiate(input.getH(), minusX);
 		GroupElement c = input.getCommitment();

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/zeroKnowledge/ZKPOKFiatShamirFromSigmaVerifier.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/zeroKnowledge/ZKPOKFiatShamirFromSigmaVerifier.java
@@ -104,8 +104,8 @@ public class ZKPOKFiatShamirFromSigmaVerifier implements ZKPOKVerifier{
 	 * This function computes the following calculations:<p>
 	 *
 	 *		IF<p>
-	 *			•	e=H(x,a,cont), AND<p>
-	 *			•	Transcript (a, e, z) is accepting in sigma on input x<p>
+	 *				e=H(x,a,cont), AND<p>
+	 *				Transcript (a, e, z) is accepting in sigma on input x<p>
 	 *     		OUTPUT ACC<p>
 	 *     ELSE<p>
 	 *          OUTPUT REJ<p>

--- a/src/java/edu/biu/scapi/interactiveMidProtocols/zeroKnowledge/ZKPOKFromSigmaCmtPedersenVerifier.java
+++ b/src/java/edu/biu/scapi/interactiveMidProtocols/zeroKnowledge/ZKPOKFromSigmaCmtPedersenVerifier.java
@@ -86,8 +86,8 @@ public class ZKPOKFromSigmaCmtPedersenVerifier implements ZKPOKVerifier{
 	 *		 RUN TRAP_COMMIT.decommit as the decommitter<p>
 	 *		 WAIT for a message (z,trap) from P<p>
 	 *		 IF  <p>
-	 *			•	TRAP_COMMIT.valid(T,trap) = 1, where T  is the transcript from the commit phase, AND<p>
-	 *			•	Transcript (a, e, z) is accepting in sigma on input x<p>
+	 *				TRAP_COMMIT.valid(T,trap) = 1, where T  is the transcript from the commit phase, AND<p>
+	 *				Transcript (a, e, z) is accepting in sigma on input x<p>
 	 *          OUTPUT ACC<p>
 	 *       ELSE 	<p>
 	 *          OUTPUT REJ<p>

--- a/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ElGamalAbs.java
+++ b/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ElGamalAbs.java
@@ -282,9 +282,9 @@ public abstract class ElGamalAbs implements ElGamalEnc{
 		}
 		/* 
 		 * Pseudo-code:
-		 * 	•	Choose a random  y <- Zq.
-		 *	•	Calculate c1 = g^y mod p //Mod p operation are performed automatically by the group.
-		 *	•	Calculate c2 = h^y * plaintext.getElement() mod p // For ElGamal on a GroupElement.
+		 * 		Choose a random  y <- Zq.
+		 *		Calculate c1 = g^y mod p //Mod p operation are performed automatically by the group.
+		 *		Calculate c2 = h^y * plaintext.getElement() mod p // For ElGamal on a GroupElement.
 		 *					OR KDF(h^y) XOR plaintext.getBytes()  // For ElGamal on a ByteArray.
 		 */
 		//Chooses a random value y<-Zq.
@@ -310,8 +310,8 @@ public abstract class ElGamalAbs implements ElGamalEnc{
 		
 		/* 
 		 * Pseudo-code:
-		 *	•	Calculate c1 = g^r mod p //Mod p operation are performed automatically by the group.
-		 *	•	Calculate c2 = h^r * plaintext.getElement() mod p // For ElGamal on a GroupElement.
+		 *		Calculate c1 = g^r mod p //Mod p operation are performed automatically by the group.
+		 *		Calculate c2 = h^r * plaintext.getElement() mod p // For ElGamal on a GroupElement.
 		 *					OR KDF(h^r) XOR plaintext.getBytes()  // For ElGamal on a ByteArray.
 		 */
 		

--- a/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScCramerShoupDDHOnGroupElement.java
+++ b/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScCramerShoupDDHOnGroupElement.java
@@ -222,7 +222,7 @@ public class ScCramerShoupDDHOnGroupElement extends CramerShoupAbs {
 			Convert u1, u2, e to byte[] using the dlogGroup
 			Compute alpha - the result of computing the hash function on the concatenation u1+ u2+ e.
 			if u_1^(x1+y1*alpha) * u_2^(x2+y2*alpha) != v throw exception
-			Calculate m = e*((u1^z)^-1)   // equal to m = e/u1^z . We don’t have a divide operation in DlogGroup so we calculate it in equivalent way
+			Calculate m = e*((u1^z)^-1)   // equal to m = e/u1^z . We don't have a divide operation in DlogGroup so we calculate it in equivalent way
 			m is a groupElement. Use it to create and return msg an instance of GroupElementPlaintext.
 			return msg
 		 */

--- a/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScDamgardJurikEnc.java
+++ b/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScDamgardJurikEnc.java
@@ -228,10 +228,10 @@ public class ScDamgardJurikEnc implements DamgardJurikEnc {
 	 */
 	public AsymmetricCiphertext encrypt(Plaintext plaintext) {
 		/*
-		 * We use the notation N=n^s, and N’ = n^(s+1).
+		 * We use the notation N=n^s, and N' = n^(s+1).
 		 * Pseudo-Code:
 		 * 		COMPUTE s=(|x|/(|n|-1)) + 1.
-		 * 		CHOOSE a random r in ZN’*.	
+		 * 		CHOOSE a random r in ZN'*.	
 		 */
 		
 		if(!(plaintext instanceof BigIntegerPlainText)){
@@ -269,11 +269,11 @@ public class ScDamgardJurikEnc implements DamgardJurikEnc {
 	 */
 	public AsymmetricCiphertext encrypt(Plaintext plainText, BigInteger r) {
 		/*
-		 * We use the notation N=n^s, and N’ = n^(s+1).
+		 * We use the notation N=n^s, and N' = n^(s+1).
 		 * Pseudo-Code:
 		 * 		COMPUTE s=(|x|/(|n|-1)) + 1.
 		 * 		CHECK that x is in ZN.
-		 *		COMPUTE c = (1+n)^x * r^N mod N’.
+		 *		COMPUTE c = (1+n)^x * r^N mod N'.
 		 * 		OUTPUT c.
 		 */
 		
@@ -325,13 +325,13 @@ public class ScDamgardJurikEnc implements DamgardJurikEnc {
 	@Override
 	public Plaintext decrypt(AsymmetricCiphertext cipher) throws KeyException{
 		/*
-		 * We use the notation N=n^s, and N’ = n^(s+1).
+		 * We use the notation N=n^s, and N' = n^(s+1).
 		 * Pseudo-Code:
 		 * 		COMPUTE s=|c| / |n|
 		 * 		CHECK that c is in ZN'.
 		 * 		COMPUTE using the Chinese Remainder Theorem a value d, such that d = 1 mod N, and d=0 mod t. 
-		 *		COMPUTE c^d mod N’.
-		 *		COMPUTE x as the discrete logarithm of c^d to the base (1+n) modulo N’. This is done by the following computation
+		 *		COMPUTE c^d mod N'.
+		 *		COMPUTE x as the discrete logarithm of c^d to the base (1+n) modulo N'. This is done by the following computation
 		 *	 	a=c^d
 		 *		x=0
 		 *		for j = 1 to s do
@@ -340,9 +340,9 @@ public class ScDamgardJurikEnc implements DamgardJurikEnc {
 		 *		   t2 = x
 		 *		   for k = 2 to j do
 		 *		   begin
-		 *		      x = x – 1
+		 *		      x = x - 1
 		 *		      t2 = t2 * x mod nj
-		 *		      t1 =  (t1 – (t2 * n^(k-1)) / factorial(k) )  mod n^j
+		 *		      t1 =  (t1 - (t2 * n^(k-1)) / factorial(k) )  mod n^j
 		 *		  end
 		 *		  x = t1
 		 *		end
@@ -385,7 +385,7 @@ public class ScDamgardJurikEnc implements DamgardJurikEnc {
 		//Computes (cipher ^ d) mod N'
 		BigInteger a = djCipher.getCipher().modPow(d, Ntag);
 		
-		//Computes x as the discrete logarithm of c^d to the base (1+n) modulo N’. This is done by the algorithm shown above.
+		//Computes x as the discrete logarithm of c^d to the base (1+n) modulo N'. This is done by the algorithm shown above.
 		BigInteger x = BigInteger.ZERO;
 		BigInteger t1, t2;
 		BigInteger nPowJ, factorialK, temp;

--- a/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScElGamalOnByteArray.java
+++ b/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScElGamalOnByteArray.java
@@ -196,8 +196,8 @@ public class ScElGamalOnByteArray extends ElGamalAbs{
 	public Plaintext decrypt(AsymmetricCiphertext cipher) throws KeyException {
 		/*  
 		 * Pseudo-code:
-		 * 	•	Calculate s = ciphertext.getC1() ^ x
-		 *	•	Calculate m = KDF(s) XOR ciphertext.getC2() 
+		 * 		Calculate s = ciphertext.getC1() ^ x
+		 *		Calculate m = KDF(s) XOR ciphertext.getC2() 
 		 */
 		
 		//If there is no private key, throws exception.

--- a/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScElGamalOnGroupElement.java
+++ b/src/java/edu/biu/scapi/midLayer/asymmetricCrypto/encryption/ScElGamalOnGroupElement.java
@@ -187,8 +187,8 @@ public class ScElGamalOnGroupElement extends ElGamalAbs implements AsymMultiplic
 	public Plaintext decrypt(AsymmetricCiphertext cipher) throws KeyException {
 		/*  
 		 * Pseudo-code:
-		 * 	•	Calculate s = ciphertext.getC1() ^ x^(-1) //x^(-1) is kept in the private key because of the optimization computed in the function initPrivateKey.
-		 *	•	Calculate m = ciphertext.getC2() * s
+		 * 		Calculate s = ciphertext.getC1() ^ x^(-1) //x^(-1) is kept in the private key because of the optimization computed in the function initPrivateKey.
+		 *		Calculate m = ciphertext.getC2() * s
 		 */
 		
 		//If there is no private key, throws exception.

--- a/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScCBCEncRandomIV.java
+++ b/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScCBCEncRandomIV.java
@@ -147,8 +147,8 @@ public class ScCBCEncRandomIV extends EncWithIVAbs implements CBCEnc {
 	@Override
 	public Plaintext decrypt(SymmetricCiphertext ciphertext) {
 		/* The algorithm pseudo-code is: 
-		 * 		•	plaintext[0] = prp.invert(cipher[0]) XOR IV
-		 *		•	For i from 1 to length of plaintext do:
+		 * 			plaintext[0] = prp.invert(cipher[0]) XOR IV
+		 *			For i from 1 to length of plaintext do:
 		 *			o	plaintext[i] : = prp.invert(cipher[i]) XOR ciphertext[i-1]
 		 */
 		if (!isKeySet()){
@@ -226,8 +226,8 @@ public class ScCBCEncRandomIV extends EncWithIVAbs implements CBCEnc {
 	@Override
 	protected IVCiphertext encAlg(byte[] plaintext, byte[] iv) {
 		/* The algorithm pseudo-code is: 
-		 * 		•	ciphertext[0] = prp.computeBlock(iv XOR plaintext[0])
-		 *		•	for next blocks in plaintext do: //i = 1
+		 * 			ciphertext[0] = prp.computeBlock(iv XOR plaintext[0])
+		 *			for next blocks in plaintext do: //i = 1
 		 *			o	ciphertext [i] = prp.computeBlock(ciphertext [i-1] XOR plaintext[i])
 		 */
 		byte[] paddedPlaintext; // Will contain the padded plaintext.

--- a/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScCTREncRandomIV.java
+++ b/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScCTREncRandomIV.java
@@ -119,11 +119,11 @@ public class ScCTREncRandomIV extends EncWithIVAbs implements CTREnc {
 	@Override
 	public Plaintext decrypt(SymmetricCiphertext ciphertext){
 		/* Pseudo-code:
-		 *    •	ctr = ciphertext.getIV
-		 *	  •	For every block in ciphertext (i = 0 to n-1) do:
+		 *    	ctr = ciphertext.getIV
+		 *	  	For every block in ciphertext (i = 0 to n-1) do:
 		 *		o	Plaintext[i] : = ciphertext[i] XOR prp.computeBlock(ctr)
 		 *		o	ctr  = ctr + 1 mod 2n
-		 *	  •	Return the plaintext.
+		 *	  	Return the plaintext.
 		 */
 		if (!isKeySet()){
 			throw new IllegalStateException("no SecretKey was set");
@@ -180,8 +180,8 @@ public class ScCTREncRandomIV extends EncWithIVAbs implements CTREnc {
 	@Override
 	protected IVCiphertext encAlg(byte[] plaintext, byte[] iv) {
 		/* Pseudo-code:
-		 * 		•	ctr = iv
-		 *		•	For each block in plaintext do: //i = 0
+		 * 			ctr = iv
+		 *			For each block in plaintext do: //i = 0
 		 *			o	cipher[i] = prp.computeBlock(ctr) XOR plaintext[i]
 		 *			o	ctr = ctr +1 mod 2n
 		 */
@@ -220,8 +220,8 @@ public class ScCTREncRandomIV extends EncWithIVAbs implements CTREnc {
 	 * If called by decrypt then the first two arguments refer to the cipher being processed and the resulting plaintext is written to "out". <p>
 	 * The data is not required to be aligned to the block size of this instance of the encryption scheme. If it is not, then the last part of the data needs special care.
 	 * Pseudo-code:
-	 * 		•out[i] = prp.computeBlock(ctr) XOR in[i]
-	 *		•ctr = ctr +1 mod 2n
+	 * 		out[i] = prp.computeBlock(ctr) XOR in[i]
+	 *		ctr = ctr +1 mod 2n
 	 * 
 	 * @param in a byte array containing the data to be processed
 	 * @param inOffset the offset in "in" byte array

--- a/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScEncryptThenMac.java
+++ b/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/ScEncryptThenMac.java
@@ -80,7 +80,7 @@ public class ScEncryptThenMac implements AuthenticatedEnc {
 
 	/**
 	 * This function supplies the encrypt-then-mac object with a Secret Key.
-	 * It calls encryptor’s relevant setKey with corresponding key and mac’s relevant setKey with corresponding key.
+	 * It calls encryptor's relevant setKey with corresponding key and mac's relevant setKey with corresponding key.
 	 * @param secretKey MUST be an instance of EncThenMacKey.
 	 * @throws InvalidKeyException if key is not of type EncThenMacKey.
 	 */

--- a/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/SymmetricEnc.java
+++ b/src/java/edu/biu/scapi/midLayer/symmetricCrypto/encryption/SymmetricEnc.java
@@ -40,7 +40,7 @@ import edu.biu.scapi.securityLevel.Indistinguishable;
 
 /**
  * This is the main interface for the Symmetric Encryption family.<p> 
- * The symmetric encryption family of classes implements three main functionalities that correspond to the cryptographer’s language 
+ * The symmetric encryption family of classes implements three main functionalities that correspond to the cryptographer's language 
  * in which an encryption scheme is composed of three algorithms:<p>
  * 	1.	Generation of the key.<p>
  *	2.	Encryption of the plaintext.<p>

--- a/src/java/edu/biu/scapi/primitives/dlog/DlogGroup.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/DlogGroup.java
@@ -255,7 +255,7 @@ public interface DlogGroup {
 	
 	/**
 	 * This function returns the value <I>k</I> which is the maximum length of a string to be encoded to a Group Element of this group.<p>
-	 * Any string of length <I>k</I> has a numeric value that is less than (p-1)/2 – 1.
+	 * Any string of length <I>k</I> has a numeric value that is less than (p-1)/2 - 1.
 	 * <I>k</I> is the maximum length a binary string is allowed to be in order to encode the said binary string to a group element and vice-versa.<p>
 	 * If a string exceeds the <I>k</I> length it cannot be encoded.
 	 * @return k the maximum length of a string to be encoded to a Group Element of this group. k can be zero if there is no maximum.

--- a/src/java/edu/biu/scapi/primitives/dlog/DlogGroupAbs.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/DlogGroupAbs.java
@@ -348,7 +348,7 @@ public abstract class DlogGroupAbs implements primeOrderSubGroup{
 	 * It performs the actual work of pre-computation of the exponentiations for one base.
 	 * It is composed of two main elements. The group element for which the optimized computations 
 	 * are built for, called the base and a vector of group elements that are the result of 
-	 * exponentiations of order 1,2,4,8,… 
+	 * exponentiations of order 1,2,4,8,
 	 */
 	private class GroupElementsExponentiations {
 		private Vector<GroupElement> exponentiations; //vector of group elements that are the result of exponentiations

--- a/src/java/edu/biu/scapi/primitives/dlog/ECFpUtility.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/ECFpUtility.java
@@ -56,7 +56,7 @@ public class ECFpUtility {
 
 	/**
 	 * Checks if the given x and y represent a valid point on the given curve, 
-	 * i.e. if the point (x, y) is a solution of the curve’s equation.
+	 * i.e. if the point (x, y) is a solution of the curves equation.
 	 * @param params elliptic curve over Fp parameters
 	 * @param x coefficient of the point
 	 * @param y coefficient of the point
@@ -155,7 +155,7 @@ public class ECFpUtility {
 
           Let L be the length in bytes of p
 
-          Choose a random byte array r of length L – k – 2 bytes 
+          Choose a random byte array r of length L - k - 2 bytes 
 
           Prepare a string newString of the following form: r || binaryString || binaryString.length (where || denotes concatenation) (i.e., the least significant byte of newString is the length of binaryString in bytes)
 

--- a/src/java/edu/biu/scapi/primitives/dlog/bc/BcDlogECF2m.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/bc/BcDlogECF2m.java
@@ -154,7 +154,7 @@ public class BcDlogECF2m extends BcAdapterDlogEC implements DlogECF2m, DDH{
 		}
 		
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// those two checks is done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership
@@ -169,7 +169,7 @@ public class BcDlogECF2m extends BcAdapterDlogEC implements DlogECF2m, DDH{
 	
 	/**
 	 * Checks if the given x and y represent a valid point on the given curve, 
-	 * i.e. if the point (x, y) is a solution of the curve’s equation.
+	 * i.e. if the point (x, y) is a solution of the curves equation.
 	 * @param params elliptic curve over F2m parameters
 	 * @param x coefficient of the point
 	 * @param y coefficient of the point

--- a/src/java/edu/biu/scapi/primitives/dlog/bc/BcDlogECFp.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/bc/BcDlogECFp.java
@@ -148,7 +148,7 @@ public class BcDlogECFp extends BcAdapterDlogEC implements DlogECFp, DDH {
 		}
 		
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// those two checks are done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership

--- a/src/java/edu/biu/scapi/primitives/dlog/miracl/MiraclDlogECF2m.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/miracl/MiraclDlogECF2m.java
@@ -365,7 +365,7 @@ public class MiraclDlogECF2m extends MiraclAdapterDlogEC implements DlogECF2m, D
 		}
 
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// those two checks is done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership

--- a/src/java/edu/biu/scapi/primitives/dlog/miracl/MiraclDlogECFp.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/miracl/MiraclDlogECFp.java
@@ -315,7 +315,7 @@ public class MiraclDlogECFp extends MiraclAdapterDlogEC implements DlogECFp, DDH
 		}
 
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// those two checks are done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership

--- a/src/java/edu/biu/scapi/primitives/dlog/openSSL/OpenSSLDlogECF2m.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/openSSL/OpenSSLDlogECF2m.java
@@ -245,7 +245,7 @@ public class OpenSSLDlogECF2m extends OpenSSLAdapterDlogEC implements DlogECF2m,
 		}
 
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// those two checks are done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership.

--- a/src/java/edu/biu/scapi/primitives/dlog/openSSL/OpenSSLDlogECFp.java
+++ b/src/java/edu/biu/scapi/primitives/dlog/openSSL/OpenSSLDlogECFp.java
@@ -225,7 +225,7 @@ public class OpenSSLDlogECFp extends OpenSSLAdapterDlogEC implements DlogECFp, D
 		}
 
 		// A point (x, y) is a member of a Dlog group with prime order q over an Elliptic Curve if it meets the following two conditions:
-		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curve’s equation.
+		// 1)	P = (x,y) is a point in the Elliptic curve, i.e (x,y) is a solution of the curves equation.
 		// 2)	P = (x,y) is a point in the q-order group which is a sub-group of the Elliptic Curve.
 		// Those two checks are done in two steps:
 		// 1.	Checking that the point is on the curve, performed by checkCurveMembership.

--- a/src/java/edu/biu/scapi/primitives/prf/IteratedPrfVarying.java
+++ b/src/java/edu/biu/scapi/primitives/prf/IteratedPrfVarying.java
@@ -100,7 +100,7 @@ public class IteratedPrfVarying extends PrfVaryingFromPrfVaryingInput {
 	 *	Let m be the smallest integer for which L*m > outlen, where L is the output length of the PrfVaryingInputLength. 
 	 *	FOR i = 1 to m 
 	 *	compute Yi = PrfVaryingInputLength(k,(x,outlen,i)) [key=k, data=(x,outlen,i)] 
-	 *	return the first outlen bits of Y1,…,Ym  
+	 *	return the first outlen bits of Y1,-,Ym  
 	 * 
 	 * This function is necessary since this prf has variable input and output length.
 	 * @param inBytes - input bytes to compute

--- a/src/java/edu/biu/scapi/primitives/prf/LubyRackoffPrpFromPrfVarying.java
+++ b/src/java/edu/biu/scapi/primitives/prf/LubyRackoffPrpFromPrfVarying.java
@@ -82,7 +82,7 @@ public final class LubyRackoffPrpFromPrfVarying extends PrpFromPrfVarying {
 	 * Computes the LubyRackoff permutation.
 	 * the algorithm pseudocode is: 
 	 * Input :
-	 *		 x = inBytes – should  be of even length                                                      
+	 *		 x = inBytes  should  be of even length                                                      
 	 *		-----------------
 	 *		Let |x|=2L (i.e., the length of the input is 2L) 
 	 *		Let L0 be the first |x|/2 bits of x 

--- a/src/java/edu/biu/scapi/primitives/prg/PseudorandomGenerator.java
+++ b/src/java/edu/biu/scapi/primitives/prg/PseudorandomGenerator.java
@@ -35,7 +35,7 @@ import javax.crypto.SecretKey;
 /** 
  * General interface of pseudorandom generator. Every concrete class in this family should implement this interface. <p>
  * 
- * A pseudorandom generator (PRG) is a deterministic algorithm that takes a “short” uniformly distributed string, 
+ * A pseudorandom generator (PRG) is a deterministic algorithm that takes a short uniformly distributed string, 
  * known as the seed, and outputs a longer string that cannot be efficiently distinguished from a uniformly 
  * distributed string of that length.
  * 

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/ScRSAPermutation.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/ScRSAPermutation.java
@@ -260,7 +260,7 @@ public final class ScRSAPermutation extends TrapdoorPermutationAbs implements RS
 	 * There are three possible validity values: 
 	 * VALID (it is an element)
 	 * NOT_VALID (it is not an element)
-	 * DON’T_KNOW (there is not enough information to check if it is an element or not)  
+	 * DONT_KNOW (there is not enough information to check if it is an element or not)  
 	 * @throws IllegalArgumentException if the given element is not a RSA element
 	 */
 	public TPElValidity isElement(TPElement tpEl) throws IllegalArgumentException{

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/TPElValidity.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/TPElValidity.java
@@ -32,7 +32,7 @@ package edu.biu.scapi.primitives.trapdoorPermutation;
  * There are three possible validity values: 
  * VALID (it is an element); 
  * NOT_VALID (it is not an element); 
- * DON’T_KNOW (there is not enough information to check if it is an element or not)
+ * DONT_KNOW (there is not enough information to check if it is an element or not)
  * 
  * @author Cryptography and Computer Security Research Group Department of Computer Science Bar-Ilan University (Moriya Farbstein)
  */

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/TrapdoorPermutation.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/TrapdoorPermutation.java
@@ -145,7 +145,7 @@ public interface TrapdoorPermutation {
 	 * There are three possible validity values: 
 	 * VALID (it is an element)
 	 * NOT_VALID (it is not an element)
-	 * DON’T_KNOW (there is not enough information to check if it is an element or not)  
+	 * DONT_KNOW (there is not enough information to check if it is an element or not)  
 	 * @throws IllegalArgumentException if the given element is invalid for this permutation
 	 */
 	public TPElValidity isElement(TPElement tpEl) throws IllegalArgumentException;

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/cryptopp/CryptoPpRSAPermutation.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/cryptopp/CryptoPpRSAPermutation.java
@@ -276,7 +276,7 @@ public final class CryptoPpRSAPermutation extends TrapdoorPermutationAbs impleme
 	 * There are three possible validity values: 
 	 * VALID (it is an element)
 	 * NOT_VALID (it is not an element)
-	 * DON’T_KNOW (there is not enough information to check if it is an element or not)  
+	 * DONT_KNOW (there is not enough information to check if it is an element or not)  
 	 * @throws - IllegalArgumentException if the given element is invalid for this RSA permutation
 	 */
 	public TPElValidity isElement(TPElement tpEl) throws IllegalArgumentException{

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/cryptopp/CryptoPpRabinPermutation.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/cryptopp/CryptoPpRabinPermutation.java
@@ -270,7 +270,7 @@ public final class CryptoPpRabinPermutation extends TrapdoorPermutationAbs imple
 	 * There are three possible validity values: 
 	 * VALID (it is an element)
 	 * NOT_VALID (it is not an element)
-	 * DON’T_KNOW (there is not enough information to check if it is an element or not)  
+	 * DONT_KNOW (there is not enough information to check if it is an element or not)  
 	 * @throws - IllegalStateException if a key has not been set
 	 * @throws - IllegalArgumentException if the given element is not CryptoPpRabinElement
 	 */

--- a/src/java/edu/biu/scapi/primitives/trapdoorPermutation/openSSL/OpenSSLRSAPermutation.java
+++ b/src/java/edu/biu/scapi/primitives/trapdoorPermutation/openSSL/OpenSSLRSAPermutation.java
@@ -281,7 +281,7 @@ public final class OpenSSLRSAPermutation extends TrapdoorPermutationAbs implemen
 	 * There are three possible validity values: 
 	 * VALID (it is an element)
 	 * NOT_VALID (it is not an element)
-	 * DON’T_KNOW (there is not enough information to check if it is an element or not)  
+	 * DONT_KNOW (there is not enough information to check if it is an element or not)  
 	 * @throws IllegalArgumentException if the given element is not a RSA element.
 	 */
 	public TPElValidity isElement(TPElement tpEl) throws IllegalArgumentException{

--- a/src/java/edu/biu/scapi/primitives/universalHash/UniversalHash.java
+++ b/src/java/edu/biu/scapi/primitives/universalHash/UniversalHash.java
@@ -70,10 +70,10 @@ public interface UniversalHash {
 	/** 
 	 * This function has multiple roles depending on the concrete hash function.
 	 * If the concrete class can get a varying input lengths then there are 2 possible answers:
-	 * 1. The maximum size of the input – if there is some kind of an upper bound on the input size 
+	 * 1. The maximum size of the input if there is some kind of an upper bound on the input size 
 	 * (for example in the EvaluationHashFunction there is a limit on the input size due to security reasons) 
 	 * thus, this function returns this bound even though the actual size can be any number between zero and that limit.
-	 * 2. Zero – if there is no limit on the input than this function returns 0.
+	 * 2. Zero if there is no limit on the input than this function returns 0.
 	 * If the concrete class can get a fixed length, this function returns a constant size that may be determined either in the init 
 	 * for some implementations or hardcoded for other implementations.
 

--- a/src/java/edu/biu/scapi/securityLevel/DlogSecLevel.java
+++ b/src/java/edu/biu/scapi/securityLevel/DlogSecLevel.java
@@ -27,7 +27,7 @@
 package edu.biu.scapi.securityLevel;
 
 /**
- * This hierarchy specifies the security level of a cyclic group in which “discrete log” hardness is assumed to hold. The levels in this hierarchy are Dlog, CDH and DDH.
+ * This hierarchy specifies the security level of a cyclic group in which discrete log hardness is assumed to hold. The levels in this hierarchy are Dlog, CDH and DDH.
  * 
  * @author Cryptography and Computer Security Research Group Department of Computer Science Bar-Ilan University (Yael Ejgenberg)
  *

--- a/src/java/edu/biu/scapi/securityLevel/ProtocolSecLevel.java
+++ b/src/java/edu/biu/scapi/securityLevel/ProtocolSecLevel.java
@@ -28,7 +28,7 @@ package edu.biu.scapi.securityLevel;
 
 /**
  * This interface is the root interface of the security level hierarchy for (secure computation) protocols.<p>
- * There are three different subhierarchies in this family. The first relates to the adversary’s capabilities and includes 
+ * There are three different subhierarchies in this family. The first relates to the adversary's capabilities and includes 
  * Semihonest, Malicious and Covert. The second relates to the question of composition and includes StandAlone and UC (universally composable). 
  * The third relates to the corruption strategy of the adversary and includes AdaptiveWithErasures and AdaptiveNoErasures 
  * (if no interface here is implemented then static security is assumed).

--- a/src/java/edu/biu/scapi/tools/Factories/FactoriesUtility.java
+++ b/src/java/edu/biu/scapi/tools/Factories/FactoriesUtility.java
@@ -84,13 +84,13 @@ class FactoriesUtility {
 	}
 	
 	/* 
-	 * parseAlgNames : The string algName should be of the form “alg1Name(alg2Name, …,algnName)”, where n can be any number greater than zero. 
-	 * (If n = zero, then AlgDetails.Name = null and AlgDetails.tail = null. If n = 1 then  AlgDetails.Name = “alg1” and AlgDetails.params=null. 
-	 * If n >=2 then AlgDetails.Name = alg1 and AlgDetails.tail = [alg2Name , …,algnName)])
-	 * •	Parse the string and return the following:
+	 * parseAlgNames : The string algName should be of the form alg1Name(alg2Name, ,algnName), where n can be any number greater than zero. 
+	 * (If n = zero, then AlgDetails.Name = null and AlgDetails.tail = null. If n = 1 then  AlgDetails.Name = alg1 and AlgDetails.params=null. 
+	 * If n >=2 then AlgDetails.Name = alg1 and AlgDetails.tail = [alg2Name , ,algnName)])
+	 * 	Parse the string and return the following:
 	 * o	If n = 0, then AlgDetails.name = null and AlgDetails.params = null. 
-	 * o	If n = 1, then AlgDetails.name = “alg1” and AlgDetails.params =null. 
-	 * If n >=2, then AlgDetails.name = “alg1” and AlgDetails.params = [alg2Name, …,algnName]
+	 * o	If n = 1, then AlgDetails.name = alg1 and AlgDetails.params =null. 
+	 * If n >=2, then AlgDetails.name = alg1 and AlgDetails.params = [alg2Name, ,algnName]
 	 * 
 	 * @param algNames a string of the form "alg1Name(alg2Name,alg3Name(alg4Name, alg5Name)" where alg1 is the main algorithm which takes
 	 * 					 other algorithms as parameters (complex algorithm) and alg3 is also a complex algorithm that takes
@@ -226,13 +226,13 @@ class FactoriesUtility {
 	/* 
 	 * pseudocode:
 	 * This function returns an Object instantiation of algName algorithm for the specified provider.
-	 * •	Check validity of AlgDetails.name. If not valid, throw exception.
-	 * •	Prepare key for map by concatenating provider + algName.
-	 * •	Get relevant class name from properties map with the key obtained.
-	 * •	Get an object of type Class representing our algorithm. (Class algClass).
-	 * •	Retrieve a Constructor of algClass that accepts t parameters of type String, while t=tailVector.length.
-	 * •	Create an instance of type algClass by calling the above Constructor. Pass as a parameter the “tailVector” in AlgDetails. The call Constructor.newInstance returns an object of type Object. (For example, if algName is a series of algorithms: "HMAC(SHA1)", the function creates an HMAC object and passes the tail – "SHA1" to the instance of HMAC. HMAC should be a class that takes as argument a string and in its constructor uses the factories to create the hash object. In this case, where there is a tail, the getObject function passes the String "SHA1" by retrieving a constructor that gets a String. If there is no such constructor, an exception will be thrown). 
-	 * •    Return the object created.
+	 * 	Check validity of AlgDetails.name. If not valid, throw exception.
+	 * 	Prepare key for map by concatenating provider + algName.
+	 * 	Get relevant class name from properties map with the key obtained.
+	 * 	Get an object of type Class representing our algorithm. (Class algClass).
+	 * 	Retrieve a Constructor of algClass that accepts t parameters of type String, while t=tailVector.length.
+	 * 	Create an instance of type algClass by calling the above Constructor. Pass as a parameter the tailVector in AlgDetails. The call Constructor.newInstance returns an object of type Object. (For example, if algName is a series of algorithms: "HMAC(SHA1)", the function creates an HMAC object and passes the tail "SHA1" to the instance of HMAC. HMAC should be a class that takes as argument a string and in its constructor uses the factories to create the hash object. In this case, where there is a tail, the getObject function passes the String "SHA1" by retrieving a constructor that gets a String. If there is no such constructor, an exception will be thrown). 
+	 * Return the object created.
 	 *
 	 * @param provider the required provider name
 	 * @param algName the required algorithm name


### PR DESCRIPTION
The changes in this commit remove 300+ errors that were produced when trying to run `javadoc`. Now running `javadoc -d doc/javadoc/SCAPI-V2-3-0/ -sourcepath src/java/ -subpackages edu` from the root of the repo completes without error.  It is worth noting that 953 warnings remain.

Most of the changes were done with a script so the spacing may not be perfect in all of the comments.

I believe that this partially addresses https://github.com/cryptobiu/scapi/issues/34.